### PR TITLE
composer/composer not required when the package is installed in a project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ php:
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
+  - php composer.phar install --dev
 
 script: phpunit -c tests/

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     "extra": {
         "class": "Baton\\Installer"
     },
-    "require": {
-        "php": ">=5.3",
+    "require-dev": {
         "composer/composer": ">=1.0.0"
     }
 }


### PR DESCRIPTION
The package composer/composer is required only for dev.
When the package is installed, the composer classes are already provided by composer.phar

Also, defining PHP 5.3 as a requirement is useless since composer does not work with PHP < 5.3
