### PR TITLE
Fix Drupal project installation paths

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,7 +4,7 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'module'    => 'sites/all/modules/{name}/',
-        'theme'     => 'sites/all/themes/{name}/',
+        'module'    => 'modules/{name}/',
+        'theme'     => 'themes/{name}/',
     );
 }


### PR DESCRIPTION
Instead of using sites/all/modules and sites/all/themes, we should instead use the straight up modules and themes directories like was there originally.

Drupal's multi-site structure allows multiple websites to host different sets of modules. Having just one composer.json file in the Drupal root restricts that from happening. Switching to just the "themes" and "modules" directories for the Composer Drupal project installation allows the following composer.json files to work properly:
- `sites/all/composer.json` (modules/themes for all your sites)
- `sites/example.com/composer.json` (modules/themes for example.com)
- `core/composer.json` (modules/themes for Drupal 8 core http://dgo.to/1424924 )
