### PR TITLE
Add support for additional Drupal projects

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -7,5 +7,6 @@ class DrupalInstaller extends BaseInstaller
         'module'    => 'modules/{$name}/',
         'theme'     => 'themes/{$name}/',
         'profile'   => 'profiles/{$name}/',
+        'drush'     => 'drush/{$name}/',
     );
 }


### PR DESCRIPTION
With Drupal, we can also support install profiles once http://drupal.org/node/562042 gets in. It also supports installing http://dgo.to/Drush components.

We might be able to do a bit more brainstorming to add additional projects, but this is pretty good for now. This is in regards to #6 .
