### PR TITLE
The idea is as to install Vendor.Package to package if aura-package <pac...

### DIFF
--- a/src/Composer/Installers/AuraInstaller.php
+++ b/src/Composer/Installers/AuraInstaller.php
@@ -1,0 +1,10 @@
+<?php
+namespace Composer\Installers;
+
+class AuraInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'package'    => 'package/{$name}/',
+        'include'     => 'include/{$name}/',
+    );
+}


### PR DESCRIPTION
...kage-name> provided and download and install 3rd party packages to include folder when aura-include is provided

I feel this will not work :P .

The idea is to keep a `composer.json` in https://github.com/auraphp/system

```
{
    "name": "auraphp/package",
    "type": "aura-package",
    "require": {
        "composer/installers": "*"
    }
}
```

I am also wondering if we are adding to other packages which can be used independently will that also download in package folder ? 

Which should go to the normal vendor directory of the user choosen .

```
"require": {
    "composer/installers": "*"
}
```

https://github.com/auraphp/Aura.Framework/blob/master/composer.json#L33
