### PR TITLE
Add Symfony2 "bundle" installer; default is src/{$vendor}/{$name}

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -102,7 +102,8 @@ abstract class BaseInstaller
     protected function mapCustomInstallPaths(array $paths, $name)
     {
         foreach ($paths as $path => $names) {
-            if (in_array($name, $names)) {
+            $pattern = str_replace('*', '.*', '{^(' . implode('|', $names) . ')$}');
+            if (preg_match($pattern, $name)) {
                 return $path;
             }
         }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -25,6 +25,7 @@ class Installer extends LibraryInstaller
         'ppi'          => 'PPIInstaller',
         'silverstripe' => 'SilverStripeInstaller',
         'symfony1'     => 'Symfony1Installer',
+        'symfony2'     => 'Symfony2Installer',
         'wordpress'    => 'WordPressInstaller',
         'zend'         => 'ZendInstaller'
     );

--- a/src/Composer/Installers/Symfony2Installer.php
+++ b/src/Composer/Installers/Symfony2Installer.php
@@ -1,0 +1,31 @@
+<?php
+namespace Composer\Installers;
+
+/**
+ * Plugin installer for symfony 2.x
+ *
+ * @author Anthon Pang <apang@softwaredevelopment.ca>
+ */
+class Symfony2Installer extends BaseInstaller
+{
+    protected $locations = array(
+        'bundle' => 'src/{$vendor}/{$name}/',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapCustomInstallPaths(array $paths, $name)
+    {
+        // allow for wildcard in name, e.g., "vendor/*-bundle"
+        foreach ($paths as $path => $names) {
+            $pattern = str_replace('*', '.*', '{^(' . implode('|', $names) . ')$}');
+
+            if (preg_match($pattern, $name)) {
+                return $path;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -92,6 +92,7 @@ class InstallerTest extends TestCase
             array('joomla-library', true),
             array('kohana-module', true),
             array('laravel-library', true),
+            array('library', false),
             array('lithium-library', true),
             array('magento-library', true),
             array('phpbb-extension', true),
@@ -99,6 +100,7 @@ class InstallerTest extends TestCase
             array('silverstripe-module', true),
             array('silverstripe-theme', true),
             array('symfony1-plugin', true),
+            array('symfony2-bundle', true),
             array('wordpress-plugin', true),
             array('zend-library', true),
         );
@@ -142,6 +144,7 @@ class InstallerTest extends TestCase
             array('silverstripe-module', 'my_module/', 'shama/my_module'),
             array('silverstripe-theme', 'themes/my_theme/', 'shama/my_theme'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sfShamaPlugin'),
+            array('symfony2-bundle', 'src/shama/shama-bundle/', 'shama/shama-bundle'),
             array('wordpress-plugin', 'wp-content/plugins/my_plugin/', 'shama/my_plugin'),
             array('zend-extra', 'extras/library/', 'shama/zend_test'),
         );
@@ -183,6 +186,27 @@ class InstallerTest extends TestCase
         ));
         $result = $installer->getInstallPath($package);
         $this->assertEquals('my/custom/path/Ftp/', $result);
+    }
+
+    /**
+     * testCustomInstallPathWithWildcard
+     */
+    public function testCustomInstallPathWithWildcard()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new MemoryPackage('shama/ftp-bundle', '1.0.0', '1.0.0');
+        $package->setType('symfony2-bundle');
+        $consumerPackage = new MemoryPackage('foo/bar', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra(array(
+            'installer-paths' => array(
+                'my/custom/path/{$name}/' => array(
+                    'shama/*-bundle',
+                ),
+            ),
+        ));
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('my/custom/path/ftp-bundle/', $result);
     }
 
     /**


### PR DESCRIPTION
Allow wildcards in custom install-path names.  Example:

```
    "extra": {
        "installer-paths": {
            "src/{$name}/": ["my-vendor/*-bundle"]
        }
    }
```
