### PR TITLE
Allow lower case package names for symfony 1 plugins

### DIFF
--- a/src/Composer/Installers/Symfony1Installer.php
+++ b/src/Composer/Installers/Symfony1Installer.php
@@ -11,4 +11,16 @@ class Symfony1Installer extends BaseInstaller
     protected $locations = array(
         'plugin'    => 'plugins/{$name}/',
     );
+
+    /**
+     * Format package name to CamelCase
+     */
+    public function inflectPackageVars($vars)
+    {
+        $vars['name'] = preg_replace_callback('/(-[a-z])/', function ($matches) {
+            return strtoupper($matches[0][1]);
+        }, $vars['name']);
+
+        return $vars;
+    }
 }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -142,6 +142,7 @@ class InstallerTest extends TestCase
             array('silverstripe-module', 'my_module/', 'shama/my_module'),
             array('silverstripe-theme', 'themes/my_theme/', 'shama/my_theme'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sfShamaPlugin'),
+            array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sf-shama-plugin'),
             array('wordpress-plugin', 'wp-content/plugins/my_plugin/', 'shama/my_plugin'),
             array('zend-extra', 'extras/library/', 'shama/zend_test'),
         );


### PR DESCRIPTION
Packagist requires lowercase package names. This allows to name the symfony 1 plugins like "sf-shama-plugin".
