### PR TITLE
Fixed: wrong locations defined for Drupal custom modules.

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,8 +4,8 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'module'    => 'modules/{$name}/',
-        'theme'     => 'themes/{$name}/',
+        'module'    => 'sites/all/modules/{$name}/',
+        'theme'     => 'sites/all/themes/{$name}/',
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
     );

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -129,8 +129,8 @@ class InstallerTest extends TestCase
         return array(
             array('cakephp-plugin', 'Plugin/Ftp/', 'shama/ftp'),
             array('codeigniter-library', 'libraries/my_package/', 'shama/my_package'),
-            array('drupal-module', 'modules/my_module/', 'shama/my_module'),
-            array('drupal-theme', 'themes/my_module/', 'shama/my_module'),
+            array('drupal-module', 'sites/all/modules/my_module/', 'shama/my_module'),
+            array('drupal-theme', 'sites/all/themes/my_module/', 'shama/my_module'),
             array('drupal-profile', 'profiles/my_module/', 'shama/my_module'),
             array('drupal-drush', 'drush/my_module/', 'shama/my_module'),
             array('fuelphp-module', 'modules/my_package/', 'shama/my_package'),


### PR DESCRIPTION
Drupal makes clear definitions where custom modules are to be located. Also the  'modules/README.txt' and' themes/README.txt' tell you that these directories are reserved for core modules or themes only. 
The designated directories for custom modules and themes are located in the 'sites/all/' directory. 
I took the liberty and changed this in this pull request.

Certainly I checked that the tests pass without error.
