### PR TITLE
Add ability to install "drupal-core" projects to the project root

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,6 +4,7 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
+        'core'      => '',
         'module'    => 'modules/{$name}/',
         'theme'     => 'themes/{$name}/',
         'profile'   => 'profiles/{$name}/',

--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,7 +4,7 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'core'      => '',
+        'core'      => 'core',
         'module'    => 'modules/{$name}/',
         'theme'     => 'themes/{$name}/',
         'profile'   => 'profiles/{$name}/',


### PR DESCRIPTION
Drupal core is to be installed to the project root. A "drupal-core" project would be:
http://drupal.org/project/drupal

I have a fork of it using the "drupal-core" type at https://packagist.org/packages/robloach/drupal .