### PR TITLE
Changed locations for Drupal module and theme types

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,8 +4,8 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'module'    => 'modules/{$name}/',
-        'theme'     => 'themes/{$name}/',
+        'module'    => 'sites/all/modules/{$name}/',
+        'theme'     => 'sites/all/themes/{$name}/',
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
     );


### PR DESCRIPTION
In a Drupal project the modules directory is reserved for core module files. Custom or contributed modules should be placed in their own subdirectory of the sites/all/modules directory.

The same is true for themes which should be placed in their own subdirectory of the sites/all/themes directory.

In my humble opinion the DrupalInstaller should reflect those coding guidelines.

Thx.
