### PR TITLE
Checking package along with consumer package for custom installer paths.

### DIFF
--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -48,7 +48,7 @@ class Installer extends LibraryInstaller
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$packageType];
         $installer = new $class($package, $this->composer);
 
-        return $installer->getInstallPath();
+        return $installer->getInstallPath($package);
     }
 
     /**

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -182,6 +182,22 @@ class InstallerTest extends TestCase
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('shama/ftp', '1.0.0', '1.0.0');
         $package->setType('cakephp-plugin');
+        $package->setExtra(array(
+            'installer-paths' => array(
+                'my/custom/path/{$name}/' => array(
+                    'shama/ftp',
+                    'foo/bar',
+                ),
+            ),
+        ));
+        $consumerPackage = new RootPackage('foo/bar', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('my/custom/path/Ftp/', $result);
+
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('shama/ftp', '1.0.0', '1.0.0');
+        $package->setType('cakephp-plugin');
         $consumerPackage = new RootPackage('foo/bar', '1.0.0', '1.0.0');
         $this->composer->setPackage($consumerPackage);
         $consumerPackage->setExtra(array(


### PR DESCRIPTION
Up to now you could only define `extra.installer-paths` on the consumer's package.
This gives more control to the package itself, allowing you to define the installer path right on your package, rather than requiring the user to do on his side.

This superseeds PR #22.
