### PR TITLE
Add Installer for TYPO3 Flow & Neos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ package type.
 * PPI           `ppi-`
 * SilverStripe  `silverstripe-`
 * Symfony1      `symfony1-`
+* TYPO3 Flow	`typo3-flow-`
 * WordPress     `wordpress-`
 * Zend          `zend-`
 
@@ -107,6 +108,13 @@ So submit your packages to [packagist.org](http://packagist.org)!
     * silverstripe-theme
 * symfony1
     * **symfony1-plugin**
+* TYPO3 Flow
+    * typo3-flow-package
+    * typo3-flow-framework
+    * typo3-flow-plugin
+    * typo3-flow-site
+    * typo3-flow-build
+    * typo3-flow-**yourlib** (will install to Packages/Yourlib/)
 * WordPress
     * **wordpress-plugin**
     * **wordpress-theme**

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "li3", "lithium", "mako","fuelphp",
         "codeigniter", "symfony", "phpbb", "ppi",
         "joomla", "wordpress", "drupal", "zend",
-        "silverstripe", "agl"
+        "silverstripe", "agl", "TYPO3 Flow", "TYPO3 Neos"
     ],
     "homepage": "http://composer.github.com/installers/",
     "authors": [

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -29,7 +29,8 @@ class Installer extends LibraryInstaller
         'silverstripe' => 'SilverStripeInstaller',
         'symfony1'     => 'Symfony1Installer',
         'wordpress'    => 'WordPressInstaller',
-        'zend'         => 'ZendInstaller'
+        'zend'         => 'ZendInstaller',
+        'typo3'        => 'TYPO3Installer'
     );
 
     /**

--- a/src/Composer/Installers/TYPO3Installer.php
+++ b/src/Composer/Installers/TYPO3Installer.php
@@ -1,0 +1,57 @@
+<?php
+namespace Composer\Installers;
+
+/**
+ * An installer to handle TYPO3 Flow specifics when installing packages.
+ */
+class TYPO3Installer extends BaseInstaller
+{
+
+    /**
+     * Modify the package name to be a TYPO3 Flow style key.
+     *
+     * @param array $vars
+     * @return array
+     */
+    public function inflectPackageVars($vars)
+    {
+
+        if (strlen($vars['type']) <= 11 || substr($vars['type'], 0, 11) !== 'typo3-flow-')
+        {
+           throw new \UnexpectedValueException('Currrently only TYPO3 Flow packages are supported by the TYPO3 installer');
+        }
+        // infer package location from package type
+        $packageLocation = strtolower(substr($vars['type'], 11));
+        switch ($packageLocation)
+        {
+            case 'package':
+                $this->locations['flow-package'] = 'Packages/Application/{$name}/';
+                break;
+            case 'plugin':
+            case 'site':
+                $this->locations['flow-' . $packageLocation] = 'Packages/' . ucfirst($packageLocation) . 's/{$name}/';
+                break;
+            case 'build':
+                $this->locations['flow-build'] = 'Build/{$name}/';
+                break;
+            default:
+                $this->locations['flow-' . $packageLocation] = 'Packages/' . ucfirst($packageLocation) . '/{$name}/';
+                break;
+        }
+
+        $autoload = $this->package->getAutoload();
+        if (isset($autoload['psr-0']) && is_array($autoload['psr-0']))
+        {
+            $namespace = key($autoload['psr-0']);
+            $vars['name'] = str_replace('\\', '.', $namespace);
+        } else {
+            $extraSettings = $this->package->getExtra();
+            if(isset($extraSettings['typo3/flow']['case-sensitive-package-name'])) {
+                $vars['name'] = $extraSettings['typo3/flow']['case-sensitive-package-name'];
+            }
+        }
+        return $vars;
+    }
+}
+
+?>


### PR DESCRIPTION
TYPO3 Flow - and Neos which are built on top - uses composer as dependency manager, but requires specific support in regards to install paths etc. This commit includes the needed installer into composer/installers
