### PR TITLE
Package type common-webroot

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -42,6 +42,7 @@ abstract class BaseInstaller
         }
 
         $availableVars = $this->inflectPackageVars(compact('name', 'vendor', 'type'));
+        $availableVars['webroot'] = '';
 
         $extra = $package->getExtra();
         if (!empty($extra['installer-name'])) {
@@ -50,12 +51,17 @@ abstract class BaseInstaller
 
         if ($this->composer->getPackage()) {
             $extra = $this->composer->getPackage()->getExtra();
+            if (!empty($extra['installer-webroot'])) {
+                $availableVars['webroot'] = $extra['installer-webroot'];
+            }
             if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName);
                 if ($customPath !== false) {
                     return $this->templatePath($customPath, $availableVars);
                 }
             }
+        } elseif ('common-webroot' === $type) {
+            throw new \InvalidArgumentException(sprintf('Package "%s" requires "installer-webroot" to be configured', $prettyName));
         }
 
         $packageType = substr($type, strlen($frameworkType) + 1);

--- a/src/Composer/Installers/CommonInstaller.php
+++ b/src/Composer/Installers/CommonInstaller.php
@@ -1,0 +1,9 @@
+<?php
+namespace Composer\Installers;
+
+class CommonInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'webroot'    => '{$webroot}/',
+    );
+}

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -30,7 +30,8 @@ class Installer extends LibraryInstaller
         'symfony1'     => 'Symfony1Installer',
         'wordpress'    => 'WordPressInstaller',
         'zend'         => 'ZendInstaller',
-        'typo3-flow'   => 'TYPO3FlowInstaller'
+        'typo3-flow'   => 'TYPO3FlowInstaller',
+        'common'       => 'CommonInstaller'
     );
 
     /**

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -178,6 +178,40 @@ class InstallerTest extends TestCase
         $package->setType('cakephp-whoops');
         $result = $installer->getInstallPath($package);
     }
+    
+    /**
+     * testCommonWebrootPackage
+     */
+    public function testCommonWebrootPackage()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('slbmeh/my_application', '1.0.0', '1.0.0');
+        
+        $package->setType('common-webroot');
+        $consumerPackage = new RootPackage('foo/bar', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra(array(
+            'installer-webroot' => 'webroot'
+        ));
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('webroot/', $result);
+    }
+
+    /**
+     * testCommonWebrootPackage
+     * 
+     * @return void
+     * 
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCommonWebrootPathException()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('slbmeh/my_application', '1.0.0', '1.0.0');
+        
+        $package->setType('common-webroot');
+        $result = $installer->getInstallPath($package);
+    }
 
     /**
      * testCustomInstallPath


### PR DESCRIPTION
Proposal for webroot themed packages.  In #38 drupal-core places the package in core.  This commit exposes a new extra in the inflected vars `{$webroot}` that can be used by packages.  It forces `installer-webroot` to be defined on the root package for a `common-webroot` package.

This proposes a package to be defined as a webroot application with a variable webroot location.  A way to assert that there is only one package of that type would be ideal, not quite sure how to implement that.
