### PR TITLE
Fixes the example directory name to be less ambiguous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to load the custom installers.
 }
 ```
 
-This would install your package to the `app/Plugin/Ftp/` folder of a CakePHP app
+This would install your package to the `Plugin/Ftp/` folder of a CakePHP app
 when a user runs `php composer.phar install`.
 
 So submit your packages to [packagist.org](http://packagist.org)!


### PR DESCRIPTION
Minor directory path fix so it's obvious that `app/` is not part of the installation path.
