### PR TITLE
Add inflection of package names for TYPO3 Flow / Neos

### DIFF
--- a/src/Composer/Installers/TYPO3FlowInstaller.php
+++ b/src/Composer/Installers/TYPO3FlowInstaller.php
@@ -13,4 +13,21 @@ class TYPO3FlowInstaller extends BaseInstaller
         'site'      => 'Packages/Sites/{$name}/',
         'build'     => 'Build/{$name}/',
     );
+
+	/**
+	 * Modify the package name to be a TYPO3 Flow style key.
+	 *
+	 * @param array $vars
+	 * @return array
+	 */
+	public function inflectPackageVars($vars)
+	{
+		$autoload = $this->package->getAutoload();
+		if (isset($autoload['psr-0']) && is_array($autoload['psr-0']))
+		{
+			$namespace = key($autoload['psr-0']);
+			$vars['name'] = str_replace('\\', '.', $namespace);
+		}
+		return $vars;
+	}
 }


### PR DESCRIPTION
Hi @shama

as promised, here is an updated patch for the TYPO3 Flow installer.

We are considering to encourage people to use the 'installer-name'-extra directly in their packages, but at least for now the inflection of package names are needed.
