### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
         "psr-0": { "Composer\\Installers\\": "src/" }
     },
     "extra": {
-        "class": "Composer\\Installers\\Installer"
+        "class": "Composer\\Installers\\Installer",
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     },
     "replace": {
         "shama/baton": "*"


### PR DESCRIPTION
Please stop telling people to use a `*` constraint. They should use something like `~1.0` or `~1.0@dev` instead.
