### PR TITLE
General Path Prefix for installer packages

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -48,14 +48,26 @@ abstract class BaseInstaller
             $availableVars['name'] = $extra['installer-name'];
         }
 
+		$prefix = "";
+		
         if ($this->composer->getPackage()) {
             $extra = $this->composer->getPackage()->getExtra();
-            if (!empty($extra['installer-paths'])) {
+            
+			if(!empty($extra['installer-prefix']))
+			{
+				$prefix = $extra['installer-prefix'];
+				//strip trailing slash
+				$prefix = rtrim($prefix, '/');
+			}
+			
+			if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName);
                 if ($customPath !== false) {
                     return $this->templatePath($customPath, $availableVars);
                 }
             }
+			
+			
         }
 
         $packageType = substr($type, strlen($frameworkType) + 1);
@@ -63,7 +75,9 @@ abstract class BaseInstaller
             throw new \InvalidArgumentException(sprintf('Package type "%s" is not supported', $type));
         }
 
-        return $this->templatePath($this->locations[$packageType], $availableVars);
+		
+		
+        return $prefix.'/'.($this->templatePath($this->locations[$packageType], $availableVars));
     }
 
     /**


### PR DESCRIPTION
Adds a new "installer-prefix" option to "extras", that allows to give a common prefix for installed packages. Prevents to restate the installation path for every new package added.

Use case:
- In your root folder, you create a composer.json and require a common web framework (such as cake-php)
- In addition to this framework, you require plugins for this framework

Now for example CakePHP gets installed to "vendor/cakephp/cakephp", but the plugins get installed to "Plugin/xyz" instead of "vender/cakephp/cakephp/Plugin".

Each and every plugin would now need to have their install path overriden with "vendor/cakephp/cakephp/xyz", which is error prone, because you always have to remember to not only include the packages into "require" but also into "installer-paths".

A global setting is IMHO the preferrable solution.

P.S: I'm preparing a pull request for a type specific installer-prefix.
