### PR TITLE
Type specific prefix path

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -53,12 +53,20 @@ abstract class BaseInstaller
         if ($this->composer->getPackage()) {
             $extra = $this->composer->getPackage()->getExtra();
             
-			if(!empty($extra['installer-prefix']))
+			if(!empty($extra['installer-prefix-'.$type]))
+			{
+				$prefix = $extra['installer-prefix-'.$type];
+				//strip trailing slash
+				$prefix = rtrim($prefix, '/');
+			}
+			else if(!empty($extra['installer-prefix']))
 			{
 				$prefix = $extra['installer-prefix'];
 				//strip trailing slash
 				$prefix = rtrim($prefix, '/');
 			}
+			
+			
 			
 			if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName);


### PR DESCRIPTION
An extension to https://github.com/composer/installers/pull/62:

Instead of only providing a general prefix path for packages, the prefix path can now be tailored to installer types, via adding "installer-prefix-{type}" to "extras".

EDIT:
Just saw https://github.com/composer/installers/pull/52, which is conceptually similar to my pull requests. IMHO the approach here is simpler both on end-user and implementation side.

Thanks for having a look at it,

Chris
