### PR TITLE
Support for SilverStripe 2

### DIFF
--- a/src/Composer/Installers/SilverStripeInstaller.php
+++ b/src/Composer/Installers/SilverStripeInstaller.php
@@ -1,10 +1,32 @@
 <?php
 namespace Composer\Installers;
 
+use Composer\Package\PackageInterface;
+
 class SilverStripeInstaller extends BaseInstaller
 {
     protected $locations = array(
         'module' => '{$name}/',
         'theme'  => 'themes/{$name}/',
     );
+
+    /**
+     * Return the install path based on package type.
+     *
+     * Relies on built-in BaseInstaller behaviour with one exception: silverstripe/framework
+     * must be installed to 'sapphire' and not 'framework' if the version is <3.0.0
+     *
+     * @param  PackageInterface $package
+     * @param  string           $frameworkType
+     * @return string
+     */
+    public function getInstallPath(PackageInterface $package, $frameworkType = '')
+    {
+        if($package->getName() == 'silverstripe/framework' && version_compare($package->getVersion(), '3.0.0') < 0) {
+            return $this->templatePath($this->locations['module'], array('name' => 'sapphire'));
+        } else {
+            return parent::getInstallPath($package, $frameworkType);
+        }
+
+    }
 }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -117,10 +117,10 @@ class InstallerTest extends TestCase
      *
      * @dataProvider dataForTestInstallPath
      */
-    public function testInstallPath($type, $path, $name)
+    public function testInstallPath($type, $path, $name, $version = '1.0.0')
     {
         $installer = new Installer($this->io, $this->composer);
-        $package = new Package($name, '1.0.0', '1.0.0');
+        $package = new Package($name, $version, $version);
 
         $package->setType($type);
         $result = $installer->getInstallPath($package);
@@ -157,6 +157,8 @@ class InstallerTest extends TestCase
             array('phpbb-language', 'language/foo/', 'test/foo'),
             array('ppi-module', 'modules/foo/', 'test/foo'),
             array('silverstripe-module', 'my_module/', 'shama/my_module'),
+            array('silverstripe-module', 'sapphire/', 'silverstripe/framework', '2.4.0'),
+            array('silverstripe-module', 'framework/', 'silverstripe/framework', '3.0.0'),
             array('silverstripe-theme', 'themes/my_theme/', 'shama/my_theme'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sfShamaPlugin'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sf-shama-plugin'),


### PR DESCRIPTION
On SilverStripe 2.x, the silverstripe/framework package needed to be installed in the directory "sapphire", rather than "framework".  This patch makes that happen without the need for special set-up.
