### PR TITLE
Add support for WordPress Must Use (MU) Plugins

### DIFF
--- a/src/Composer/Installers/WordPressInstaller.php
+++ b/src/Composer/Installers/WordPressInstaller.php
@@ -6,5 +6,6 @@ class WordPressInstaller extends BaseInstaller
     protected $locations = array(
         'plugin'    => 'wp-content/plugins/{$name}/',
         'theme'     => 'wp-content/themes/{$name}/',
+        'muplugin'  => 'wp-content/mu-plugins/{$name}/',
     );
 }


### PR DESCRIPTION
Adds support for the WordPress must use plugins directory (mu-plugins).  This directory is for WordPress plugins that are automatically loaded.  This new installer type is called `wordpress-muplugin`.

See http://codex.wordpress.org/Must_Use_Plugins for more information about this directory.
