### PR TITLE
Fix zend-library and zend-extra

### DIFF
--- a/src/Composer/Installers/ZendInstaller.php
+++ b/src/Composer/Installers/ZendInstaller.php
@@ -4,7 +4,7 @@ namespace Composer\Installers;
 class ZendInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'library' => 'library/',
-        'extra'   => 'extras/library/',
+        'library' => 'library/{$name}/',
+        'extra'   => 'extras/library/{$name}/',
     );
 }


### PR DESCRIPTION
Presently, the library and extra location rules are incorrectly installing all package files in library/ and extras/library/, respectively, instead of placing them in the correct named directories.
