### PR TITLE
Fixed SilverStripe detection on non-numeric versions

### DIFF
--- a/src/Composer/Installers/SilverStripeInstaller.php
+++ b/src/Composer/Installers/SilverStripeInstaller.php
@@ -22,7 +22,11 @@ class SilverStripeInstaller extends BaseInstaller
      */
     public function getInstallPath(PackageInterface $package, $frameworkType = '')
     {
-        if($package->getName() == 'silverstripe/framework' && version_compare($package->getVersion(), '3.0.0') < 0) {
+        if (
+            $package->getName() == 'silverstripe/framework' 
+            && preg_match('/^\d+\.\d+\.\d+/', $package->getVersion()) 
+            && version_compare($package->getVersion(), '3.0.0') < 0
+        ) {
             return $this->templatePath($this->locations['module'], array('name' => 'sapphire'));
         } else {
             return parent::getInstallPath($package, $frameworkType);

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -167,6 +167,8 @@ class InstallerTest extends TestCase
             array('silverstripe-module', 'my_module/', 'shama/my_module'),
             array('silverstripe-module', 'sapphire/', 'silverstripe/framework', '2.4.0'),
             array('silverstripe-module', 'framework/', 'silverstripe/framework', '3.0.0'),
+            array('silverstripe-module', 'framework/', 'silverstripe/framework', '3.0.0-rc1'),
+            array('silverstripe-module', 'framework/', 'silverstripe/framework', 'my/branch'),
             array('silverstripe-theme', 'themes/my_theme/', 'shama/my_theme'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sfShamaPlugin'),
             array('symfony1-plugin', 'plugins/sfShamaPlugin/', 'shama/sf-shama-plugin'),


### PR DESCRIPTION
The old version detection broke the Travis builds for forks, since the 'version'
in this case is the branch name, which can't be compared
with `version_compare()`. This lead to the core folder always
being renamed to `sapphire/` (instead of leaving it with
the newer naming of `framework/`). Which in turn caused test
execution failure because the bootstrap path wasn't found.

The patch doesn't guard against branch names which are based off 2.x
(with the old `sapphire/` folder naming, since composer doesn't have this
branch point information, but rather adapts to the most common usage.

/cc @sminnee
