### PR TITLE
Prefix CodeIgniter paths with "application"

### DIFF
--- a/src/Composer/Installers/CodeIgniterInstaller.php
+++ b/src/Composer/Installers/CodeIgniterInstaller.php
@@ -4,8 +4,8 @@ namespace Composer\Installers;
 class CodeIgniterInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'library'     => 'libraries/{$name}/',
-        'third-party' => 'third_party/{$name}/',
-        'module'      => 'modules/{$name}/',
+        'library'     => 'application/libraries/{$name}/',
+        'third-party' => 'application/third_party/{$name}/',
+        'module'      => 'application/modules/{$name}/',
     );
 }


### PR DESCRIPTION
The CodeIgniter documentation states that the default path for any third_party material is at:
application/libraries
application/third_party
application/modules

http://ellislab.com/codeigniter/user-guide/libraries/loader.html

The current implementation of installers puts the dependency in the root of the project. Having it in the root prevents CodeIgniter's autoloader from detecting the dependency. 

While CodeIgniter does allow for the application folder to be changed, this requires editing the default index.php that comes with CI. If someone wants to change the default application folder, then they should also have to modify their composer.json file accordingly, but by default, it installers should stick with CI's default dependency directories.

Thanks!
