### PR TITLE
Fixing the CamelCased plugin name case + unit test for CakePHP installer

### DIFF
--- a/src/Composer/Installers/CakePHPInstaller.php
+++ b/src/Composer/Installers/CakePHPInstaller.php
@@ -12,7 +12,8 @@ class CakePHPInstaller extends BaseInstaller
      */
     public function inflectPackageVars($vars)
     {
-        $vars['name'] = strtolower(str_replace(array('-', '_'), ' ', $vars['name']));
+        $vars['name'] = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $vars['name']));
+        $vars['name'] = str_replace(array('-', '_'), ' ', $vars['name']);
         $vars['name'] = str_replace(' ', '', ucwords($vars['name']));
 
         return $vars;

--- a/tests/Composer/Installers/Test/CakePHPInstallerTest.php
+++ b/tests/Composer/Installers/Test/CakePHPInstallerTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Composer\Installers\Test;
+
+use Composer\Package\Package;
+use Composer\Composer;
+use Composer\Config;
+
+class CakePHPInstallerTest extends TestCase
+{
+    private $composer;
+    private $config;
+    private $vendorDir;
+    private $binDir;
+    private $dm;
+    private $repository;
+    private $io;
+    private $fs;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+	    $this->package = new Package('CamelCased', '1.0', '1.0');
+	    $this->io = $this->getMock('Composer\IO\PackageInterface');
+	    $this->composer = new Composer();
+    }
+
+    /**
+     * tearDown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+
+    }
+
+    /**
+     * testInflectPackageVars
+     *
+     * @return void
+     */
+    public function testInflectPackageVars()
+    {
+        $installer = new \Composer\Installers\CakePHPInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'CamelCased'));
+        $this->assertEquals($result, array('name' => 'CamelCased'));
+
+        $installer = new \Composer\Installers\CakePHPInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'with-dash'));
+        $this->assertEquals($result, array('name' => 'WithDash'));
+
+        $installer = new \Composer\Installers\CakePHPInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'with_underscore'));
+        $this->assertEquals($result, array('name' => 'WithUnderscore'));
+    }
+
+}


### PR DESCRIPTION
Fixing the CamelCased plugin name case and adding a test case for the CakePHP installer
