### PR TITLE
Installing binaries throws exception because installers incorrectly return relative paths

### DIFF
--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -1,12 +1,16 @@
 <?php
 namespace Composer\Installers;
 
+use Composer\Composer;
 use Composer\Installer\LibraryInstaller;
+use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 
 class Installer extends LibraryInstaller
 {
+    protected $workingDir;
+
     /**
      * Package types to installer class map
      *
@@ -42,6 +46,16 @@ class Installer extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
+    public function __construct(IOInterface $io, Composer $composer, $type = 'library')
+    {
+        parent::__construct($io, $composer, $type);
+        $this->workingDir = getcwd();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
     public function getInstallPath(PackageInterface $package)
     {
         $type = $package->getType();
@@ -56,7 +70,7 @@ class Installer extends LibraryInstaller
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$frameworkType];
         $installer = new $class($package, $this->composer);
 
-        return $installer->getInstallPath($package, $frameworkType);
+        return $this->workingDir.DIRECTORY_SEPARATOR.$installer->getInstallPath($package, $frameworkType);
     }
 
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -139,14 +139,14 @@ class InstallerTest extends TestCase
      *
      * @dataProvider dataForTestInstallPath
      */
-    public function testInstallPath($type, $path, $name, $version = '1.0.0')
+    public function testInstallPath($type, $relpath, $name, $version = '1.0.0')
     {
         $installer = new Installer($this->io, $this->composer);
         $package = new Package($name, $version, $version);
 
         $package->setType($type);
         $result = $installer->getInstallPath($package);
-        $this->assertEquals($path, $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.$relpath, $result);
     }
 
     /**
@@ -236,7 +236,7 @@ class InstallerTest extends TestCase
             ),
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('my/custom/path/Ftp/', $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.'my/custom/path/Ftp/', $result);
     }
 
     /**
@@ -250,7 +250,7 @@ class InstallerTest extends TestCase
             'installer-name' => 'FTP',
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('Plugin/FTP/', $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.'Plugin/FTP/', $result);
     }
 
     /**
@@ -270,7 +270,7 @@ class InstallerTest extends TestCase
             ),
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('my/custom/path/my_plugin/', $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.'my/custom/path/my_plugin/', $result);
     }
 
     /**
@@ -283,7 +283,7 @@ class InstallerTest extends TestCase
 
         $package->setType('symfony1-plugin');
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('plugins/sfPhpunitPlugin/', $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.'plugins/sfPhpunitPlugin/', $result);
     }
 
     /**
@@ -302,7 +302,7 @@ class InstallerTest extends TestCase
 
         $package->setType('typo3-flow-package');
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('Packages/Application/TYPO3.Fluid/', $result);
+        $this->assertEquals($this->workingDir.DIRECTORY_SEPARATOR.'Packages/Application/TYPO3.Fluid/', $result);
     }
 
     public function testUninstallAndDeletePackageFromLocalRepo()


### PR DESCRIPTION
Composer cannot install declared binaries for a package that uses custom installers. Attempting to do so throws an InvalidArgumentException from [Composer/Util/Filesystem:201](https://github.com/composer/composer/blob/master/src/Composer/Util/Filesystem.php#L201) with the message "From {path} and to {path} must be absolute paths".

This is because the inherited Composer LibraryInstaller returns absolute paths from getInstallPath (having first called realpath() to get the absolute path to the configured vendor directory), but the installers in the composer/installers return relative paths. 

The same issue has been reported on composer/composer#1589 although that one appeared to be with his own custom installer rather than one from this package. I've not been able to reproduce the issue @xrstf mentioned there with autoload_namespaces following this change - composer seems to handle marking the paths as being relative to $baseDir.

He's right that the [composer docs](https://github.com/composer/composer/blob/master/doc/articles/custom-installers.md) say the path should be relative, but I have verified this is not the case with the standard installer.

I have implemented a test case that proves the exception, and a second commit which fixes it by returning absolute paths and fixing all the other tests that expect relative ones. I couldn't see a way to test without actually attempting to install a fake package with binaries, and based my new test case on what I could see in composer/composer and composer/installers - not sure if that's how you'd want to handle it but it does work.

I'm pushing the commits separately so that you see travis builds on each. I guess you'll want to have a bit of a look at this, as although it's in theory a small change and tested I'm not familiar enough with composer internals to guarantee this won't break something outside the test coverage...
