### PR TITLE
Fix for custom install path can't link file of bin-dir

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -106,7 +106,7 @@ abstract class BaseInstaller
             }
         }
 
-        return $path;
+        return realpath('./') . DIRECTORY_SEPARATOR . trim($path, '\\/');
     }
 
     /**


### PR DESCRIPTION
See issue https://github.com/composer/composer/issues/2230

If the library of custom install have some code like:

``` json
{
"bin" : [
    "bin/merge-assets"
  ]
}
```

while install fail.

Output error message like:

```
  [InvalidArgumentException]
  $from (~/Sites/test4/bin/merge-assets) and $to (libraries/test//bin/mer
  ge-assets) must be absolute paths.
```
