### PR TITLE
Add feature namespace installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
   - curl -s http://getcomposer.org/installer | php -- --quiet
   - php composer.phar install --dev
 
-script: phpunit
+script: phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ is not needed to install packages with these frameworks:
 | Magento      | `magento-library`<br>`magento-skin`<br>`magento-theme`
 | Mako         | `mako-package`
 | MediaWiki    | `mediawiki-extension`
+| Namespace    | `namespace-vendor-package`
 | OXID         | `oxid-module`
 | MODULEWork   | `modulework-module`
 | phpBB        | `phpbb-extension`<br>`phpbb-style`<br>`phpbb-language`
@@ -107,7 +108,7 @@ A package type can have a custom installation path with a `type:` prefix.
 ```
 
 This would use your custom path for each of the listed packages. The available
-variables to use in your paths are: `{$name}`, `{$vendor}`, `{$type}`.
+variables to use in your paths are: `{$name}`, `{$vendor}`, `{$type}` and `{$vendorDir}`.
 
 ## Custom Install Names
 

--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -32,7 +32,7 @@ abstract class BaseInstaller
     public function getInstallPath(PackageInterface $package, $frameworkType = '')
     {
         $type = $this->package->getType();
-
+        $vendorDir = $this->composer->getConfig()->get('vendor-dir');
         $prettyName = $this->package->getPrettyName();
         if (strpos($prettyName, '/') !== false) {
             list($vendor, $name) = explode('/', $prettyName);
@@ -41,7 +41,7 @@ abstract class BaseInstaller
             $name = $prettyName;
         }
 
-        $availableVars = $this->inflectPackageVars(compact('name', 'vendor', 'type'));
+        $availableVars = $this->inflectPackageVars(compact('name', 'vendor', 'type', 'vendorDir'));
 
         $extra = $package->getExtra();
         if (!empty($extra['installer-name'])) {

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -28,6 +28,7 @@ class Installer extends LibraryInstaller
         'mako'         => 'MakoInstaller',
         'mediawiki'    => 'MediaWikiInstaller',
         'modulework'   => 'MODULEWorkInstaller',
+        'namespace'    => 'NamespaceInstaller',
         'oxid'         => 'OxidInstaller',
         'phpbb'        => 'PhpBBInstaller',
         'ppi'          => 'PPIInstaller',

--- a/src/Composer/Installers/NamespaceInstaller.php
+++ b/src/Composer/Installers/NamespaceInstaller.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Composer Installers
+ */
+namespace Composer\Installers;
+
+use Composer\Composer;
+use Composer\Package\PackageInterface;
+
+/**
+ * Custom namespace installer for Composer.
+ * This installer converts the vendor and package name
+ * to CamelCase suitable to be used as a formal namespace.
+ * @example vendor-name/package-name to VendorName/PackageName
+ */
+class NamespaceInstaller extends BaseInstaller
+{
+    /**
+     * Installation locations
+     * @var array
+     */
+    protected $locations = array(
+        'vendor-package' => '{$vendorDir}/{$vendor}/{$name}/',
+    );
+
+    /**
+     * Substitute package variables
+     * @param array $vars
+     * @return array
+     */
+    public function inflectPackageVars($vars)
+    {
+        $vars['name']   = $this->formatToCamelCase($vars['name']);
+        $vars['vendor'] = $this->formatToCamelCase($vars['vendor']);
+
+        return $vars;
+    }
+
+    /**
+     * Format string to CamelCase keeping existing uppercase chars.
+     * @param string $string
+     * @return string
+     */
+    protected function formatToCamelCase($string)
+    {
+        $string = str_replace('-', ' ', $string);
+        return str_replace(' ', '', ucwords($string));
+    }
+}

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -30,7 +30,6 @@ class InstallerTest extends TestCase
 
         $this->composer = new Composer();
         $this->config = new Config();
-        $this->composer->setConfig($this->config);
 
         $this->vendorDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'baton-test-vendor';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
@@ -44,6 +43,7 @@ class InstallerTest extends TestCase
                 'bin-dir' => $this->binDir,
             ),
         ));
+        $this->composer->setConfig($this->config);
 
         $this->dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
             ->disableOriginalConstructor()
@@ -109,6 +109,7 @@ class InstallerTest extends TestCase
             array('mako-package', true),
             array('mediawiki-extension', true),
             array('modulework-module', true),
+            array('namespace-vendor-package', true),
             array('phpbb-extension', true),
             array('ppi-module', true),
             array('silverstripe-module', true),
@@ -168,6 +169,7 @@ class InstallerTest extends TestCase
             array('mediawiki-extension', 'extensions/UploadWizard/', 'author/upload-wizard' ),
             array('mediawiki-extension', 'extensions/SyntaxHighlight_GeSHi/', 'author/syntax-highlight_GeSHi' ),
             array('modulework-module', 'modules/my_package/', 'shama/my_package'),
+            array('namespace-vendor-package', realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'baton-test-vendor' . '/VendorName/PackageName/', 'vendor-name/package-name' ),
             array('phpbb-extension', 'ext/test/foo/', 'test/foo'),
             array('phpbb-style', 'styles/foo/', 'test/foo'),
             array('phpbb-language', 'language/foo/', 'test/foo'),


### PR DESCRIPTION
Custom namespace installer for Composer.
This installer converts the vendor and package name to CamelCase suitable to be used as a formal namespace (example: vendor-name/package-name to VendorName/PackageName).
