### PR TITLE
Added theme support for FuelInstaller

### DIFF
--- a/src/Composer/Installers/FuelInstaller.php
+++ b/src/Composer/Installers/FuelInstaller.php
@@ -6,5 +6,6 @@ class FuelInstaller extends BaseInstaller
     protected $locations = array(
         'module'  => 'fuel/app/modules/{$name}/',
         'package' => 'fuel/packages/{$name}/',
+        'theme'   => 'fuel/themes/{$name}/',
     );
 }


### PR DESCRIPTION
Please note that there is no default location for themes in FuelPHP 1.x, but this path is mentioned as a possible default in the docs. Make sure to change the config. (Actually there is a default, but it is in the DOCROOT, which is not recommended)
