### PR TITLE
Add Support for PSR-4 in TYPO3FlowInstaller

### DIFF
--- a/src/Composer/Installers/TYPO3FlowInstaller.php
+++ b/src/Composer/Installers/TYPO3FlowInstaller.php
@@ -28,6 +28,10 @@ class TYPO3FlowInstaller extends BaseInstaller
             $namespace = key($autoload['psr-0']);
             $vars['name'] = str_replace('\\', '.', $namespace);
         }
+        if (isset($autoload['psr-4']) && is_array($autoload['psr-4'])) {
+            $namespace = key($autoload['psr-4']);
+            $vars['name'] = rtrim(str_replace('\\', '.', $namespace), '.');
+        }
         return $vars;
     }
 }


### PR DESCRIPTION
This pull-request adds the support for the PSR-4 standard to the TYPO3FlowInstaller.
Without this the resulting directory name under which PSR-4 packages are installed
have an incompatible name which the TYPO3 Flow packageManager doesn't understand

Related TYPO3.Flow Change: https://review.typo3.org/28097
