### PR TITLE
Add drupal-library to Drupal Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ is not needed to install packages with these frameworks:
 | concrete5    | `concrete5-block`<br>`concrete5-package`<br>`concrete5-theme`<br>`concrete5-update`
 | Craft        | `craft-plugin`
 | Croogo       | `croogo-plugin`<br>`croogo-theme`
-| Drupal       | <b>`drupal-module`<br>`drupal-theme`</b><br>`drupal-profile`<br>`drupal-drush`
+| Drupal       | <b>`drupal-module`<br>`drupal-theme`</b><br>`drupal-library`<br>`drupal-profile`<br>`drupal-drush`
 | Elgg         | `elgg-plugin`
 | FuelPHP v1.x | `fuel-module`<br>`fuel-package`<br/>`fuel-theme`
 | Hurad        | `hurad-plugin`<br>`hurad-theme`

--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -6,6 +6,7 @@ class DrupalInstaller extends BaseInstaller
     protected $locations = array(
         'module'    => 'modules/{$name}/',
         'theme'     => 'themes/{$name}/',
+        'library'     => 'libraries/{$name}/',
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
     );


### PR DESCRIPTION
I need to be able to install libraries into Drupal projects. By default they should live in sites/all/libraries/{$name}

This simple patch works for me.

Let me know if you have any questions.
