### PR TITLE
Extended OXID installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ is not needed to install packages with these frameworks:
 | MODX Evo     | `modxevo-snippet`<br>`modxevo-plugin`<br>`modxevo-module`<br>`modxevo-template`<br>`modxevo-lib`
 | MediaWiki    | `mediawiki-extension`
 | October      | **`october-module`<br>`october-plugin`**
-| OXID         | `oxid-module`
+| OXID         | `oxid-module`<br>`oxid-theme`<br>`oxid-out`
 | MODULEWork   | `modulework-module`
 | Piwik        | `piwik-plugin`
 | phpBB        | `phpbb-extension`<br>`phpbb-style`<br>`phpbb-language`

--- a/src/Composer/Installers/OxidInstaller.php
+++ b/src/Composer/Installers/OxidInstaller.php
@@ -5,5 +5,7 @@ class OxidInstaller extends BaseInstaller
 {
     protected $locations = array(
         'module'    => 'modules/{$name}/',
+        'theme'  => 'application/views/{$name}/',
+        'out'    => 'out/{$name}/',
     );
 }


### PR DESCRIPTION
It’s now possible to install OXID themes and OXID asset folders via
composer
