### PR TITLE
Allow plugin to be installed under Plugin/Vendorname/Pluginname directory

### DIFF
--- a/src/Composer/Installers/CakePHPInstaller.php
+++ b/src/Composer/Installers/CakePHPInstaller.php
@@ -12,9 +12,13 @@ class CakePHPInstaller extends BaseInstaller
      */
     public function inflectPackageVars($vars)
     {
-        $vars['name'] = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $vars['name']));
-        $vars['name'] = str_replace(array('-', '_'), ' ', $vars['name']);
-        $vars['name'] = str_replace(' ', '', ucwords($vars['name']));
+        $nameParts = explode('/', $vars['name']);
+        foreach ($nameParts as &$value) {
+            $value = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $value));
+            $value = str_replace(array('-', '_'), ' ', $value);
+            $value = str_replace(' ', '', ucwords($value));
+        }
+        $vars['name'] = implode('/', $nameParts);
 
         return $vars;
     }

--- a/tests/Composer/Installers/Test/CakePHPInstallerTest.php
+++ b/tests/Composer/Installers/Test/CakePHPInstallerTest.php
@@ -40,6 +40,14 @@ class CakePHPInstallerTest extends TestCase
         $installer = new CakePHPInstaller($this->package, $this->composer);
         $result = $installer->inflectPackageVars(array('name' => 'with_underscore'));
         $this->assertEquals($result, array('name' => 'WithUnderscore'));
+
+        $installer = new CakePHPInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'cake/acl'));
+        $this->assertEquals($result, array('name' => 'Cake/Acl'));
+
+        $installer = new CakePHPInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'cake/debug-kit'));
+        $this->assertEquals($result, array('name' => 'Cake/DebugKit'));
     }
 
 }


### PR DESCRIPTION
This should allow a cakephp plugin named "cake/acl" in composer config to be installed under `APP/Plugin/Cake/Acl` directory. Before this patch you had to specify the plugin name without vendor namespace using the "installer-name" config.

/cc @markstory @lorenzo
