### PR TITLE
Changes theme package path

### DIFF
--- a/src/Composer/Installers/FuelInstaller.php
+++ b/src/Composer/Installers/FuelInstaller.php
@@ -6,6 +6,6 @@ class FuelInstaller extends BaseInstaller
     protected $locations = array(
         'module'  => 'fuel/app/modules/{$name}/',
         'package' => 'fuel/packages/{$name}/',
-        'theme'   => 'fuel/themes/{$name}/',
+        'theme'   => 'fuel/app/themes/{$name}/',
     );
 }


### PR DESCRIPTION
According to [this](https://github.com/fuel/core/issues/1717) issue the default theme path is changed to an acceptable one, also the theme path used now in installer is not standard, so updated it to the new one.
