### PR TITLE
contao installer

### DIFF
--- a/src/Composer/Installers/ContaoInstaller.php
+++ b/src/Composer/Installers/ContaoInstaller.php
@@ -1,0 +1,28 @@
+<?php
+namespace Composer\Installers;
+
+class ContaoInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'module' => 'system/modules/{$name}/',
+        'plugin' => 'plugins/{$name}/',
+    );
+
+    /**
+     * Format package vars.
+     */
+    public function inflectPackageVars($vars)
+    {
+        $vars = $this->inflectPackageName($vars);
+
+        return $vars;
+    }
+
+    protected function inflectPackageName($vars)
+    {
+        $vars['name'] = strtolower($vars['name']);
+
+        return $vars;
+    }
+
+}

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -59,6 +59,7 @@ class Installer extends LibraryInstaller
         'typo3-flow'   => 'TYPO3FlowInstaller',
         'typo3-cms'    => 'TYPO3CmsInstaller',
         'tusk'         => 'TuskInstaller',
+        'contao'       => 'ContaoInstaller',
     );
 
     /**

--- a/tests/Composer/Installers/Test/ContaoInstallerTest.php
+++ b/tests/Composer/Installers/Test/ContaoInstallerTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Composer\Installers\Test;
+
+use Composer\Installers\CakePHPInstaller;
+use Composer\Installers\ContaoInstaller;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\InstalledArrayRepository;
+use Composer\Package\Package;
+use Composer\Package\RootPackage;
+use Composer\Package\Link;
+use Composer\Package\Version\VersionParser;
+use Composer\Composer;
+
+class ContaoInstallerTest extends TestCase
+{
+    private $package;
+    private $composer;
+    private $io;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->package = new Package('CamelCased', '1.0', '1.0');
+        $this->package->setExtra(array(
+                'installer-name' => 'cased',
+                'contao-major-version' => 2
+            ));
+        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->composer = new Composer();
+    }
+
+    /**
+     * testInflectPackageVars
+     *
+     * @return void
+     */
+    public function testInflectPackageVars()
+    {
+        $installer = new ContaoInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'CamelCased'));
+        $this->assertEquals($result, array('name' => 'camelcased'));
+
+        $installer = new ContaoInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'alllowercase'));
+        $this->assertEquals($result, array('name' => 'alllowercase'));
+
+        $installer = new ContaoInstaller($this->package, $this->composer);
+        $result = $installer->inflectPackageVars(array('name' => 'with-dash'));
+        $this->assertEquals($result, array('name' => 'with-dash'));
+    }
+
+}


### PR DESCRIPTION
This is a installer for contao module and plugins. By now only usable for contao 2.x

Should I make a new class for Contao 3.x (Contao3Installer) or try to handle that by an extra-parameter like `contao-major-version`?

Feedback very welcome!