### PR TITLE
Custom Types (root-only)

### DIFF
--- a/src/Composer/Installers/CustomInstaller.php
+++ b/src/Composer/Installers/CustomInstaller.php
@@ -1,0 +1,7 @@
+<?php
+namespace Composer\Installers;
+
+class CustomInstaller extends BaseInstaller
+{
+    protected $locations = array();
+}

--- a/src/Composer/Installers/CustomInstaller.php
+++ b/src/Composer/Installers/CustomInstaller.php
@@ -3,5 +3,4 @@ namespace Composer\Installers;
 
 class CustomInstaller extends BaseInstaller
 {
-    protected $locations = array();
 }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -69,7 +69,7 @@ class Installer extends LibraryInstaller
         $type = $package->getType();
 
         if ($this->isCustomType($type)) {
-          $installer = new BaseInstaller($package, $this->composer);
+          $installer = new CustomInstaller($package, $this->composer);
           return $installer->getInstallPath($package);
         }
 

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -67,6 +67,12 @@ class Installer extends LibraryInstaller
     public function getInstallPath(PackageInterface $package)
     {
         $type = $package->getType();
+
+        if ($this->isCustomType($type)) {
+          $installer = new Composer\Installers\BaseInstaller($package, $this->composer);
+          return $installer->getInstallPath($package);
+        }
+
         $frameworkType = $this->findFrameworkType($type);
 
         if ($frameworkType === false) {
@@ -98,6 +104,10 @@ class Installer extends LibraryInstaller
      */
     public function supports($packageType)
     {
+        if ($this->isCustomType($packageType)) {
+          return true;
+        }
+
         $frameworkType = $this->findFrameworkType($packageType);
 
         if ($frameworkType === false) {
@@ -149,4 +159,28 @@ class Installer extends LibraryInstaller
 
         return $pattern ? : '(\w+)';
     }
+
+    /**
+     * Determines if current type is a custom Type.
+     *
+     * @param  string $type
+     * @return bool
+     */
+    protected function isCustomType($type)
+    {
+
+        if ($this->composer->getPackage()) {
+          $extra = $this->composer->getPackage()->getExtra();
+          if (!empty($extra['installer-paths'])) {
+            foreach $extra['installer-paths'] as $path => $names) {
+              if (in_array('type:' . $type, $names)) {
+                  return true;
+              }
+            }
+          }
+        }
+
+        return false;
+    }
+
 }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -69,7 +69,7 @@ class Installer extends LibraryInstaller
         $type = $package->getType();
 
         if ($this->isCustomType($type)) {
-          $installer = new Composer\Installers\BaseInstaller($package, $this->composer);
+          $installer = new BaseInstaller($package, $this->composer);
           return $installer->getInstallPath($package);
         }
 

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -67,15 +67,10 @@ class Installer extends LibraryInstaller
     public function getInstallPath(PackageInterface $package)
     {
         $type = $package->getType();
-
-        if ($this->isCustomType($type)) {
-          $installer = new CustomInstaller($package, $this->composer);
-          return $installer->getInstallPath($package);
-        }
-
         $frameworkType = $this->findFrameworkType($type);
+        $custom = $this->isCustomType($type);        }
 
-        if ($frameworkType === false) {
+        if ($frameworkType === false && $custom === false) {
             throw new \InvalidArgumentException(
                 'Sorry the package type of this package is not yet supported.'
             );
@@ -83,6 +78,11 @@ class Installer extends LibraryInstaller
 
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$frameworkType];
         $installer = new $class($package, $this->composer);
+
+        if ($custom && !in_array($type, $installer->getLocations())) {
+            $frameworkType = 'custom';
+            $installer = new CustomInstaller($package, $this->composer);
+        }
 
         return $installer->getInstallPath($package, $frameworkType);
     }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -68,9 +68,9 @@ class Installer extends LibraryInstaller
     {
         $type = $package->getType();
         $frameworkType = $this->findFrameworkType($type);
-        $custom = $this->isCustomType($type);        }
+        $custom = $this->isCustomType($type);
 
-        if ($frameworkType === false && $custom === false) {
+        if ($frameworkType === false && !$custom) {
             throw new \InvalidArgumentException(
                 'Sorry the package type of this package is not yet supported.'
             );

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -79,7 +79,10 @@ class Installer extends LibraryInstaller
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$frameworkType];
         $installer = new $class($package, $this->composer);
 
-        if ($custom && !in_array($type, $installer->getLocations())) {
+        $packageType = substr($type, strlen($frameworkType) + 1);
+        $locations = $installer->getLocations();
+
+        if ($custom && !isset($locations[$packageType])) {
             $frameworkType = 'custom';
             $installer = new CustomInstaller($package, $this->composer);
         }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -172,7 +172,7 @@ class Installer extends LibraryInstaller
         if ($this->composer->getPackage()) {
           $extra = $this->composer->getPackage()->getExtra();
           if (!empty($extra['installer-paths'])) {
-            foreach $extra['installer-paths'] as $path => $names) {
+            foreach ($extra['installer-paths'] as $path => $names) {
               if (in_array('type:' . $type, $names)) {
                   return true;
               }

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -70,10 +70,18 @@ class Installer extends LibraryInstaller
         $frameworkType = $this->findFrameworkType($type);
         $custom = $this->isCustomType($type);
 
-        if ($frameworkType === false && !$custom) {
-            throw new \InvalidArgumentException(
-                'Sorry the package type of this package is not yet supported.'
-            );
+        if ($frameworkType === false) {
+
+            if ($custom) {
+              $frameworkType = 'custom';
+              $installer = new CustomInstaller($package, $this->composer);
+              return $installer->getInstallPath($package, $frameworkType);
+            }
+            else {
+              throw new \InvalidArgumentException(
+                  'Sorry the package type of this package is not yet supported.'
+              );
+            }
         }
 
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$frameworkType];


### PR DESCRIPTION
This pull request allows a user to define custom package type locations in the root `composer.json` file. This happens seamlessly by simply defining [Custom Install Paths](https://github.com/composer/installers#custom-install-paths) by `type` For a complete description, please see #180.

Ideally, this should also support names as well, but since [Composer\Installer\InstallerInterface::supports()](https://github.com/composer/composer/blob/master/src/Composer/Installer/InstallerInterface.php#L32) only provides $type as a string, I don't think that is possible right now.
