### PR TITLE
Adds FuelPHP 2.x component installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ is not needed to install packages with these frameworks:
 | Drupal       | <b>`drupal-module`<br>`drupal-theme`</b><br>`drupal-library`<br>`drupal-profile`<br>`drupal-drush`
 | Elgg         | `elgg-plugin`
 | FuelPHP v1.x | `fuel-module`<br>`fuel-package`<br/>`fuel-theme`
+| FuelPHP v2.x | `fuelphp-component`
 | Grav         | `grav-plugin`<br>`grav-theme`
 | Hurad        | `hurad-plugin`<br>`hurad-theme`
 | Joomla       | `joomla-component`<br>`joomla-module`<br>`joomla-template`<br>`joomla-plugin`<br>`joomla-library`

--- a/src/Composer/Installers/FuelphpInstaller.php
+++ b/src/Composer/Installers/FuelphpInstaller.php
@@ -1,0 +1,9 @@
+<?php
+namespace Composer\Installers;
+
+class FuelphpInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'component'  => 'components/{$name}/',
+    );
+}

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -26,6 +26,7 @@ class Installer extends LibraryInstaller
         'drupal'       => 'DrupalInstaller',
         'elgg'         => 'ElggInstaller',
         'fuel'         => 'FuelInstaller',
+        'fuelphp'      => 'FuelphpInstaller',
         'grav'         => 'GravInstaller',
         'hurad'        => 'HuradInstaller',
         'joomla'       => 'JoomlaInstaller',


### PR DESCRIPTION
Waiting for @WanWizard (project lead of FuelPHP) to confirm this is good to go.

@WanWizard: I removed the feature that trimmed fuelphp- prefix and -component suffix from package names since this one lets you to define custom package name.

Syntax:

``` json
"extra": {
    "installer-name": "component-name"
 },
```

Are you satisfied with it? Should the feature mentioned above go back?
