### PR TITLE
Added type oxid-shop

### DIFF
--- a/src/Composer/Installers/OxidInstaller.php
+++ b/src/Composer/Installers/OxidInstaller.php
@@ -4,8 +4,9 @@ namespace Composer\Installers;
 class OxidInstaller extends BaseInstaller
 {
     protected $locations = array(
+	'shop'		=> '{$name}/',
         'module'    => 'modules/{$name}/',
         'theme'  => 'application/views/{$name}/',
-        'out'    => 'out/{$name}/',
+        'out'    => 'out/{$name}/'
     );
 }


### PR DESCRIPTION
I added a new type to the Oxid installer, In order to install the Oxid Shop that a collegue of mine forked and made composer ready. This way, you can determine the path where the shop is installed using installer-paths. Also remove a unnecesary comma.
