### PR TITLE
CakePHP 3.x plugins are just vendors

### DIFF
--- a/src/Composer/Installers/CakePHPInstaller.php
+++ b/src/Composer/Installers/CakePHPInstaller.php
@@ -34,7 +34,7 @@ class CakePHPInstaller extends BaseInstaller
     public function getLocations()
     {
         if ($this->matchesCakeVersion('>=', '3.0.0')) {
-            $this->locations['plugin'] = 'plugins/{$name}/';
+            $this->locations['plugin'] = 'vendor/{$name}/';
         }
         return $this->locations;
     }

--- a/tests/Composer/Installers/Test/CakePHPInstallerTest.php
+++ b/tests/Composer/Installers/Test/CakePHPInstallerTest.php
@@ -94,11 +94,11 @@ class CakePHPInstallerTest extends TestCase
         // cakephp >= 3.0
         $this->setCakephpVersion($rm, '3.0.*-dev');
         $result = $installer->getLocations();
-        $this->assertContains('plugins/', $result['plugin']);
+        $this->assertContains('vendor/', $result['plugin']);
 
         $this->setCakephpVersion($rm, '~8.8');
         $result = $installer->getLocations();
-        $this->assertContains('plugins/', $result['plugin']);
+        $this->assertContains('vendor/', $result['plugin']);
     }
 
     /**


### PR DESCRIPTION
While users don't need this repository in 3.x, if it's required - ensure plugins go in the right (the default) place.

Closes:

 * https://github.com/composer/installers/issues/211
 * https://github.com/composer/installers/issues/217
 * https://github.com/cakephp/plugin-installer/issues/18

Hmm looks like I've overlooked a few things...