### PR TITLE
TYPO3FlowInstaller now replaces only non-trailing \\

### DIFF
--- a/src/Composer/Installers/TYPO3FlowInstaller.php
+++ b/src/Composer/Installers/TYPO3FlowInstaller.php
@@ -26,11 +26,11 @@ class TYPO3FlowInstaller extends BaseInstaller
         $autoload = $this->package->getAutoload();
         if (isset($autoload['psr-0']) && is_array($autoload['psr-0'])) {
             $namespace = key($autoload['psr-0']);
-            $vars['name'] = str_replace('\\', '.', $namespace);
+            $vars['name'] = preg_replace('\\\\(?!$)', '.', $namespace);
         }
         if (isset($autoload['psr-4']) && is_array($autoload['psr-4'])) {
             $namespace = key($autoload['psr-4']);
-            $vars['name'] = rtrim(str_replace('\\', '.', $namespace), '.');
+            $vars['name'] = rtrim(preg_replace('\\\\(?!$)', '.', $namespace), '.');
         }
 
         return $vars;


### PR DESCRIPTION
since the trailing doble backslashes are recommended ([PSR-0](https://getcomposer.org/doc/04-schema.md#psr-0)) or even required ([PSR-4](https://getcomposer.org/doc/04-schema.md#psr-4)).