### PR TITLE
composer: fix deprecated type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "composer/installers",
-    "type": "composer-installer",
+    "type": "composer-plugin",
     "license": "MIT",
     "description": "A multi-framework Composer library installer",
     "keywords": [


### PR DESCRIPTION
`composer-installer` is deprecated, use `composer-plugin` instead.

See https://github.com/composer/composer/commit/5be0ba14fe9fa2cf129ab1fc2c189254b0748886