### PR TITLE
Updates composer command and link in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ not be inflected.
 
 * [Fork and clone](https://help.github.com/articles/fork-a-repo).
 * Run the command `php composer.phar install` to install the dependencies. 
-  This will also install the dev dependencies. See [Composer](https://github.com/composer/composer#installation--usage).
+  This will also install the dev dependencies. See [Composer](https://getcomposer.org/doc/03-cli.md#install).
 * Use the command `phpunit` to run the tests. See [PHPUnit](http://phpunit.de).
 * Create a branch, commit, push and send us a
   [pull request](https://help.github.com/articles/using-pull-requests).

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ not be inflected.
 ## Contribute!
 
 * [Fork and clone](https://help.github.com/articles/fork-a-repo).
-* Run the command `php composer.phar install --dev` to install the dev
-  dependencies. See [Composer](https://github.com/composer/composer#installation--usage).
+* Run the command `php composer.phar install` to install the dependencies. 
+  This will also install the dev dependencies. See [Composer](https://github.com/composer/composer#installation--usage).
 * Use the command `phpunit` to run the tests. See [PHPUnit](http://phpunit.de).
 * Create a branch, commit, push and send us a
   [pull request](https://help.github.com/articles/using-pull-requests).


### PR DESCRIPTION
Minor improvements:

- The `--dev` flag is not required. Development dependencies are installed by default, unless the `--no-dev` flag is used.
- The link now points to the install usage section in the online manual rather than the README on github.
