### PR TITLE
Add WordPress dropin support

### DIFF
--- a/src/Composer/Installers/WordPressInstaller.php
+++ b/src/Composer/Installers/WordPressInstaller.php
@@ -7,6 +7,6 @@ class WordPressInstaller extends BaseInstaller
         'plugin'    => 'wp-content/plugins/{$name}/',
         'theme'     => 'wp-content/themes/{$name}/',
         'muplugin'  => 'wp-content/mu-plugins/{$name}/',
-        'dropin'    => 'wp-content/{name}/',
+        'dropin'    => 'wp-content/{$name}/',
     );
 }

--- a/src/Composer/Installers/WordPressInstaller.php
+++ b/src/Composer/Installers/WordPressInstaller.php
@@ -7,5 +7,6 @@ class WordPressInstaller extends BaseInstaller
         'plugin'    => 'wp-content/plugins/{$name}/',
         'theme'     => 'wp-content/themes/{$name}/',
         'muplugin'  => 'wp-content/mu-plugins/{$name}/',
+        'dropin'    => 'wp-content/{name}/',
     );
 }


### PR DESCRIPTION
WordPress alows to replace some functions with Dropins.
This small change in the commit allow to add via composer the dropin.

Below is a table with all Dropins I know or I have found. The possible Dropins are echoing via the function `_get_dropins()`.

| FILE | TYPE OF DROPIN | ACTIVE SINCE | CONTEXT |
| --- | --- | --- | --- |
| advanced-cache.php | Advanced or Alternative Cache | Constant WP_CACHEis TRUE | Single Installation |
| db.php | Own database class | Always | Single installation |
| db-error.php | Own database error alert | At DB Error | Single installation |
| install.php | Own installation routine | At installation | Single installation |
| maintenance.php | Own maintenance message | At updates, maintenance | Single installation |
| object-cache.php | External Object Cache | Always | Single installation |
| sunrise.php | Before the WP Multisite Installation gets loaded | If constant SUNRISEset | Multisite installation |
| blog-deleted.php | Own message, when a blog gets deleted | If a blog gets deleted | Multisite installation |
| blog-inactive.php | Own message, if a blog is set inactive | If a blog becomes inactive | Multisite installation |
| blog-suspended.php | Own message, if a blog got suspended | When a blog gets marked as archive or spam | Multisite installation |
| $locale.php | functions at active language key | When language key set in constant WP_LANG | Single & multisite installation |
