### PR TITLE
Create custom theme/module paths for drupal 8.

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -11,6 +11,6 @@ class DrupalInstaller extends BaseInstaller
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
 	    'custom-theme' => 'themes/custom/{$name}/',
-	    'custom-module' => 'modules/custom//{$name}',
+	    'custom-module' => 'modules/custom/{$name}',
     );
 }

--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -10,5 +10,7 @@ class DrupalInstaller extends BaseInstaller
         'library'   => 'libraries/{$name}/',
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
+	'custom-theme' => 'themes/custom/{$name}/',
+	'custom-module' => 'modules/custom//{$name}'.
     );
 }

--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -10,7 +10,7 @@ class DrupalInstaller extends BaseInstaller
         'library'   => 'libraries/{$name}/',
         'profile'   => 'profiles/{$name}/',
         'drush'     => 'drush/{$name}/',
-	'custom-theme' => 'themes/custom/{$name}/',
-	'custom-module' => 'modules/custom//{$name}'.
+	    'custom-theme' => 'themes/custom/{$name}/',
+	    'custom-module' => 'modules/custom//{$name}',
     );
 }


### PR DESCRIPTION
module/custom/{$name} is a common path used in drupal, since we can't use custom/dynamic types according to documentation, these should be available. 