### PR TITLE
Update getInstallPath() to return an absolute path

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -57,7 +57,7 @@ abstract class BaseInstaller
             if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type);
                 if ($customPath !== false) {
-                    return $this->templatePath($customPath, $availableVars);
+                    return getcwd() . '/' . $this->templatePath($customPath, $availableVars);
                 }
             }
         }
@@ -68,7 +68,7 @@ abstract class BaseInstaller
             throw new \InvalidArgumentException(sprintf('Package type "%s" is not supported', $type));
         }
 
-        return $this->templatePath($locations[$packageType], $availableVars);
+        return getcwd() . '/' . $this->templatePath($locations[$packageType], $availableVars);
     }
 
     /**

--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -57,7 +57,7 @@ abstract class BaseInstaller
             if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type);
                 if ($customPath !== false) {
-                    return getcwd() . '/' . $this->templatePath($customPath, $availableVars);
+                    return $this->templatePath($customPath, $availableVars);
                 }
             }
         }
@@ -68,7 +68,7 @@ abstract class BaseInstaller
             throw new \InvalidArgumentException(sprintf('Package type "%s" is not supported', $type));
         }
 
-        return getcwd() . '/' . $this->templatePath($locations[$packageType], $availableVars);
+        return $this->templatePath($locations[$packageType], $availableVars);
     }
 
     /**
@@ -111,7 +111,26 @@ abstract class BaseInstaller
             }
         }
 
+        if ($this->isAbsolutePath($path) === false) {
+            $path = getcwd() . '/' . $path;
+        }
+
         return $path;
+    }
+
+    /**
+     * Return true if $path provided is absolute
+     *
+     * @param  string $path
+     * @return boolean 
+     */
+    protected function isAbsolutePath($path)
+    {
+        if ($path === null || $path === '') {
+            return false;
+        }
+
+        return $path[0] === DIRECTORY_SEPARATOR || preg_match('~\A[A-Z]:(?![^/\\\\])~i',$path) > 0;
     }
 
     /**


### PR DESCRIPTION
This is to address an issue preventing path repos from working with
Installers. They require an absolute path for creating a symlink