### PR TITLE
Add frontend- and backend-theme-option for Shopware 5+

### DIFF
--- a/src/Composer/Installers/ShopwareInstaller.php
+++ b/src/Composer/Installers/ShopwareInstaller.php
@@ -11,7 +11,9 @@ class ShopwareInstaller extends BaseInstaller
         'backend-plugin'    => 'engine/Shopware/Plugins/Local/Backend/{$name}/',
         'core-plugin'       => 'engine/Shopware/Plugins/Local/Core/{$name}/',
         'frontend-plugin'   => 'engine/Shopware/Plugins/Local/Frontend/{$name}/',
-        'theme'             => 'templates/{$name}/'
+        'theme'             => 'templates/{$name}/',
+        'backend-theme'     => 'themes/Backend/{$name}',
+        'frontend-theme'    => 'themes/Frontend/{$name}',
     );
 
     /**


### PR DESCRIPTION
Shopware 5.0+ uses the `themes`-directory instead of `templates`. In `V5.2` the support for `templates` will be dropped, so I've added the new structure as well w/ an extra type.