### PR TITLE
Drop-in plugin support for WordPress

### DIFF
--- a/src/Composer/Installers/WordPressInstaller.php
+++ b/src/Composer/Installers/WordPressInstaller.php
@@ -7,5 +7,6 @@ class WordPressInstaller extends BaseInstaller
         'plugin'    => 'wp-content/plugins/{$name}/',
         'theme'     => 'wp-content/themes/{$name}/',
         'muplugin'  => 'wp-content/mu-plugins/{$name}/',
+        'dropin'    => 'wp-content/',
     );
 }


### PR DESCRIPTION
WordPress drop-in plugins are located in the root of `wp-content`. In most cases, these are advanced configuration tools to overload inner workings of WordPress, like the object-cache, main database class, output caching, etc...

A full list of supported drop-ins can be most conveniently found in this blog post from a prolific WordPress contributor:

https://hakre.wordpress.com/2010/05/01/must-use-and-drop-ins-plugins/