### PR TITLE
Support custom paths per vendor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,20 @@ A package type can have a custom installation path with a `type:` prefix.
 }
 ```
 
-This would use your custom path for each of the listed packages. The available
+You can also have the same vendor packages with a custom installation path by
+using the `vendor:` prefix.
+
+``` json
+{
+    "extra": {
+        "installer-paths": {
+            "your/custom/path/{$name}/": ["vendor:my_organization"]
+        }
+    }
+}
+```
+
+These would use your custom path for each of the listed packages. The available
 variables to use in your paths are: `{$name}`, `{$vendor}`, `{$type}`.
 
 ## Custom Install Names

--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -55,7 +55,7 @@ abstract class BaseInstaller
         if ($this->composer->getPackage()) {
             $extra = $this->composer->getPackage()->getExtra();
             if (!empty($extra['installer-paths'])) {
-                $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type);
+                $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type, $vendor);
                 if ($customPath !== false) {
                     return $this->templatePath($customPath, $availableVars);
                 }
@@ -120,12 +120,13 @@ abstract class BaseInstaller
      * @param  array  $paths
      * @param  string $name
      * @param  string $type
+     * @param  string $vendor = NULL
      * @return string
      */
-    protected function mapCustomInstallPaths(array $paths, $name, $type)
+    protected function mapCustomInstallPaths(array $paths, $name, $type, $vendor = NULL)
     {
         foreach ($paths as $path => $names) {
-            if (in_array($name, $names) || in_array('type:' . $type, $names)) {
+            if (in_array($name, $names) || in_array('type:' . $type, $names) || in_array('vendor:' . $vendor, $names)) {
                 return $path;
             }
         }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -379,6 +379,27 @@ class InstallerTest extends TestCase
     }
 
     /**
+     * testVendorPath
+     */
+    public function testVendorPath()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('penyaskito/my_module', '1.0.0', '1.0.0');
+        $package->setType('drupal-module');
+        $consumerPackage = new RootPackage('drupal/drupal', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra(array(
+          'installer-paths' => array(
+            'modules/custom/{$name}/' => array(
+              'vendor:penyaskito'
+            ),
+          ),
+        ));
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('modules/custom/my_module/', $result);
+    }
+
+    /**
      * testNoVendorName
      */
     public function testNoVendorName()


### PR DESCRIPTION
This way we can support things like:
```javascript
    "extra": {
        "installer-paths": {
            "web/modules/custom/{$name}": [
                "vendor:my_organization"
            ],
         }
     }
```