### PR TITLE
Add Drupal root type

### DIFF
--- a/src/Composer/Installers/DrupalInstaller.php
+++ b/src/Composer/Installers/DrupalInstaller.php
@@ -4,6 +4,7 @@ namespace Composer\Installers;
 class DrupalInstaller extends BaseInstaller
 {
     protected $locations = array(
+        'root'      => './',
         'core'      => 'core/',
         'module'    => 'modules/{$name}/',
         'theme'     => 'themes/{$name}/',


### PR DESCRIPTION
Allow management of Drupal's webroot files. Drupal ships `index.php`, along with a few other configuration files. This provides a `drupal-root` type, allowing changing where the root is installed.