### PR TITLE
bitrix components path now include vendor name of package

### DIFF
--- a/src/Composer/Installers/BitrixInstaller.php
+++ b/src/Composer/Installers/BitrixInstaller.php
@@ -27,7 +27,7 @@ class BitrixInstaller extends BaseInstaller
 {
     protected $locations = array(
         'module'    => '{$bitrix_dir}/modules/{$name}/',
-        'component' => '{$bitrix_dir}/components/{$name}/',
+        'component' => '{$bitrix_dir}/components/{$vendor}/{$name}/',
         'theme'     => '{$bitrix_dir}/templates/{$name}/',
     );
 

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -214,7 +214,7 @@ class InstallerTest extends TestCase
             array('annotatecms-component', 'addons/components/my_component/', 'vysinsky/my_component'),
             array('annotatecms-service', 'addons/services/my_service/', 'vysinsky/my_service'),
             array('bitrix-module', 'bitrix/modules/my_module/', 'author/my_module'),
-            array('bitrix-component', 'bitrix/components/my_component/', 'author/my_component'),
+            array('bitrix-component', 'bitrix/components/author/my_component/', 'author/my_component'),
             array('bitrix-theme', 'bitrix/templates/my_theme/', 'author/my_theme'),
             array('bonefish-package', 'Packages/bonefish/package/', 'bonefish/package'),
             array('cakephp-plugin', 'Plugin/Ftp/', 'shama/ftp'),


### PR DESCRIPTION
The problem:

Now it's impossible to create several packages (components) for one vendor name.

Bitrix he uses vendor-name for components file system structure. i.e
```
-components
  -bitrix //it's a vendor name
    -blog //it's a component name
```
But ```BitrixInstaller``` installs package (component) in the components/{$name} dir, so bitrix filesystem logic now is broken.
```
-components
  - bitrix //it's a vendor name
    -blog //it's a component
    -.......
  -my_component //it's a component, but was installed like a vendor
```
So, it's impossible to install several components with one vendor name. My package must be a 'bitrix vendor folder'...

May be it's better to use vendor name of package like a vendor name of bitrix component? 


P.S. Bitrix do not use the same logic for modules and templates, so this patch is actual only for components.