### PR TITLE
Revert "Support "atto" editor plugins introduced in Moodle 2.7+"

### DIFF
--- a/src/Composer/Installers/MoodleInstaller.php
+++ b/src/Composer/Installers/MoodleInstaller.php
@@ -51,7 +51,6 @@ class MoodleInstaller extends BaseInstaller
         'webservice'         => 'webservice/{$name}/',
         'workshopallocation' => 'mod/workshop/allocation/{$name}/',
         'workshopeval'       => 'mod/workshop/eval/{$name}/',
-        'workshopform'       => 'mod/workshop/form/{$name}/',
-        'editor_atto_plugin' => 'lib/editor/atto/plugins/{$name}/'
+        'workshopform'       => 'mod/workshop/form/{$name}/'
     );
 }


### PR DESCRIPTION
Reverts composer/installers#201 which was unnecessary as atto editor plugins are already supported using the type "atto", which is the correct Moodle plugin type name for these plugins.