### PR TITLE
Return absolute paths as LibraryInstaller does

### DIFF
--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -97,7 +97,11 @@ class Installer extends LibraryInstaller
         $class = 'Composer\\Installers\\' . $this->supportedTypes[$frameworkType];
         $installer = new $class($package, $this->composer, $this->getIO());
 
-        return $installer->getInstallPath($package, $frameworkType);
+        $basePath = realpath(getcwd());
+
+        $installPath = $installer->getInstallPath($package, $frameworkType);
+
+        return $basePath.'/'.$installPath;
     }
 
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -32,6 +32,9 @@ class InstallerTest extends TestCase
         $this->config = new Config();
         $this->composer->setConfig($this->config);
 
+        $this->rootDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'baton-test-root-package';
+        $this->ensureDirectoryExistsAndClear($this->rootDir);
+
         $this->vendorDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'baton-test-vendor';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 
@@ -61,6 +64,7 @@ class InstallerTest extends TestCase
      */
     public function tearDown()
     {
+        $this->fs->removeDirectory($this->rootDir);
         $this->fs->removeDirectory($this->vendorDir);
         $this->fs->removeDirectory($this->binDir);
     }
@@ -198,12 +202,17 @@ class InstallerTest extends TestCase
      */
     public function testInstallPath($type, $path, $name, $version = '1.0.0')
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package($name, $version, $version);
 
         $package->setType($type);
         $result = $installer->getInstallPath($package);
-        $this->assertEquals($path, $result);
+        $this->assertEquals($this->rootDir.'/'.$path, $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -354,6 +363,9 @@ class InstallerTest extends TestCase
      */
     public function testCustomInstallPath()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('shama/ftp', '1.0.0', '1.0.0');
         $package->setType('cakephp-plugin');
@@ -368,7 +380,9 @@ class InstallerTest extends TestCase
             ),
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('my/custom/path/Ftp/', $result);
+        $this->assertEquals($this->rootDir.'/my/custom/path/Ftp/', $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -376,6 +390,9 @@ class InstallerTest extends TestCase
      */
     public function testCustomInstallerName()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('shama/cakephp-ftp-plugin', '1.0.0', '1.0.0');
         $package->setType('cakephp-plugin');
@@ -383,7 +400,9 @@ class InstallerTest extends TestCase
             'installer-name' => 'FTP',
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('Plugin/FTP/', $result);
+        $this->assertEquals($this->rootDir.'/Plugin/FTP/', $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -391,6 +410,9 @@ class InstallerTest extends TestCase
      */
     public function testCustomTypePath()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('slbmeh/my_plugin', '1.0.0', '1.0.0');
         $package->setType('wordpress-plugin');
@@ -404,7 +426,9 @@ class InstallerTest extends TestCase
             ),
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('my/custom/path/my_plugin/', $result);
+        $this->assertEquals($this->rootDir.'/my/custom/path/my_plugin/', $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -412,6 +436,9 @@ class InstallerTest extends TestCase
      */
     public function testVendorPath()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('penyaskito/my_module', '1.0.0', '1.0.0');
         $package->setType('drupal-module');
@@ -425,7 +452,9 @@ class InstallerTest extends TestCase
           ),
         ));
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('modules/custom/my_module/', $result);
+        $this->assertEquals($this->rootDir.'/modules/custom/my_module/', $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -433,12 +462,17 @@ class InstallerTest extends TestCase
      */
     public function testNoVendorName()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('sfPhpunitPlugin', '1.0.0', '1.0.0');
 
         $package->setType('symfony1-plugin');
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('plugins/sfPhpunitPlugin/', $result);
+        $this->assertEquals($this->rootDir.'/plugins/sfPhpunitPlugin/', $result);
+
+        chdir($currentWorkDir);
     }
 
     /**
@@ -446,6 +480,9 @@ class InstallerTest extends TestCase
      */
     public function testTypo3Inflection()
     {
+        $currentWorkDir = getcwd();
+        chdir($this->rootDir);
+
         $installer = new Installer($this->io, $this->composer);
         $package = new Package('typo3/fluid', '1.0.0', '1.0.0');
 
@@ -457,7 +494,9 @@ class InstallerTest extends TestCase
 
         $package->setType('typo3-flow-package');
         $result = $installer->getInstallPath($package);
-        $this->assertEquals('Packages/Application/TYPO3.Fluid/', $result);
+        $this->assertEquals($this->rootDir.'/Packages/Application/TYPO3.Fluid/', $result);
+
+        chdir($currentWorkDir);
     }
 
     public function testUninstallAndDeletePackageFromLocalRepo()


### PR DESCRIPTION
The `LibraryInstaller` class does an ensure directory exists and a realpath on the `getInstallPath` method.  This does similar, getting realpath of cwd.

Potential BC breakage, relative paths specified in a custom install path will now become absolute. I feel this should be the correct behavior, otherwise it can lead to weird and potentially malicious things.
