### PR TITLE
Add support for framework prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ using the `vendor:` prefix.
 }
 ```
 
+Additionaly you can install packages for a specific framework to a custom directory with `framework:` prefix.
+
+``` json
+{
+    "extra": {
+        "installer-paths": {
+            "your/custom/path/{$resolved_path}/": ["framework:moodle"]
+        }
+    }
+}
+```
 These would use your custom path for each of the listed packages. The available
 variables to use in your paths are: `{$name}`, `{$vendor}`, `{$type}`.
 

--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -52,12 +52,19 @@ abstract class BaseInstaller
             $availableVars['name'] = $extra['installer-name'];
         }
 
+        $prefix = '';
         if ($this->composer->getPackage()) {
             $extra = $this->composer->getPackage()->getExtra();
             if (!empty($extra['installer-paths'])) {
                 $customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $prettyName, $type, $vendor);
                 if ($customPath !== false) {
                     return $this->templatePath($customPath, $availableVars);
+                }
+                foreach ($extra['installer-paths'] as $path => $framework) {
+                    if ($framework = 'framework:' . $frameworkType) {
+                        $prefix = $path;
+                        break;
+                    }
                 }
             }
         }
@@ -68,7 +75,7 @@ abstract class BaseInstaller
             throw new \InvalidArgumentException(sprintf('Package type "%s" is not supported', $type));
         }
 
-        return $this->templatePath($locations[$packageType], $availableVars);
+        return $prefix . $this->templatePath($locations[$packageType], $availableVars);
     }
 
     /**

--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -60,8 +60,8 @@ abstract class BaseInstaller
                 if ($customPath !== false) {
                     return $this->templatePath($customPath, $availableVars);
                 }
-                foreach ($extra['installer-paths'] as $path => $framework) {
-                    if ($framework = 'framework:' . $frameworkType) {
+                foreach ($extra['installer-paths'] as $path => $frameworks) {
+                    if (in_array('framework:' . $frameworkType, $frameworks)) {
                         $prefix = $path;
                         break;
                     }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -448,6 +448,29 @@ class InstallerTest extends TestCase
         $this->assertEquals('modules/custom/my_module/', $result);
     }
 
+
+
+    /**
+     * testFrameworkPath
+     */
+    public function testFrameworkPath()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('blckct/my_module', '1.0.0', '1.0.0');
+        $package->setType('drupal-module');
+        $consumerPackage = new RootPackage('drupal/drupal', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra(array(
+            'installer-paths' => array(
+                'drupal/' => array(
+                    'framework:drupal'
+                ),
+            ),
+        ));
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('drupal/modules/my_module/', $result);
+    }
+
     /**
      * testNoVendorName
      */

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -456,19 +456,37 @@ class InstallerTest extends TestCase
     public function testFrameworkPath()
     {
         $installer = new Installer($this->io, $this->composer);
-        $package = new Package('blckct/my_module', '1.0.0', '1.0.0');
-        $package->setType('drupal-module');
-        $consumerPackage = new RootPackage('drupal/drupal', '1.0.0', '1.0.0');
-        $this->composer->setPackage($consumerPackage);
-        $consumerPackage->setExtra(array(
+        $extra = array(
             'installer-paths' => array(
+                'moodle/' => array(
+                    'framework:moodle'
+                ),
                 'drupal/' => array(
                     'framework:drupal'
                 ),
             ),
-        ));
+        );
+        $package = new Package('blckct/my_module', '1.0.0', '1.0.0');
+        $package->setType('drupal-module');
+        $consumerPackage = new RootPackage('drupal/drupal', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra($extra);
         $result = $installer->getInstallPath($package);
         $this->assertEquals('drupal/modules/my_module/', $result);
+
+        $package = new Package('blckct/my_block', '1.0.0', '1.0.0');
+        $package->setType('moodle-block');
+        $consumerPackage = new RootPackage('drupal/drupal', '1.0.0', '1.0.0');
+        $this->composer->setPackage($consumerPackage);
+        $consumerPackage->setExtra($extra);
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('moodle/blocks/my_block/', $result);
+
+        $package = new Package('sfPhpunitPlugin', '1.0.0', '1.0.0');
+        $package->setType('symfony1-plugin');
+        $consumerPackage->setExtra($extra);
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('plugins/sfPhpunitPlugin/', $result);
     }
 
     /**


### PR DESCRIPTION
It was already mentioned in #148 by @Mihailoff , I think it's a useful case to direct whole frameworks to specific paths instead of overriding specific modules on at a time.

```
{
    "extra": {
        "installer-paths-prefix": {
          "framework-folder": ["framework:wordpress"]
        }
    }
```

}
