### PR TITLE
Add OntoWiki installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ is not needed to install packages with these frameworks:
 | MODX Evo     | `modxevo-snippet`<br>`modxevo-plugin`<br>`modxevo-module`<br>`modxevo-template`<br>`modxevo-lib`
 | MediaWiki    | `mediawiki-extension`
 | October      | **`october-module`<br>`october-plugin`<br>`october-theme`**
+| OntoWiki     | `ontowiki-extension`<br>`ontowiki-theme`<br>`ontowiki-translation`
 | OXID         | `oxid-module`<br>`oxid-theme`<br>`oxid-out`
 | MODULEWork   | `modulework-module`
 | Moodle       | `moodle-*` (Please [check source](https://raw.githubusercontent.com/composer/installers/master/src/Composer/Installers/MoodleInstaller.php) for all supported types)

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -61,6 +61,7 @@ class Installer extends LibraryInstaller
         'modxevo'      => 'MODXEvoInstaller',
         'moodle'       => 'MoodleInstaller',
         'october'      => 'OctoberInstaller',
+        'ontowiki'     => 'OntoWikiInstaller',
         'oxid'         => 'OxidInstaller',
         'phpbb'        => 'PhpBBInstaller',
         'pimcore'      => 'PimcoreInstaller',

--- a/src/Composer/Installers/OntoWikiInstaller.php
+++ b/src/Composer/Installers/OntoWikiInstaller.php
@@ -1,0 +1,24 @@
+<?php
+namespace Composer\Installers;
+
+class OntoWikiInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'extension' => 'extensions/{$name}/',
+        'theme' => 'extensions/themes/{$name}/',
+        'translation' => 'extensions/translations/{$name}/',
+    );
+
+    /**
+     * Format package name to lower case and remove ".ontowiki" suffix
+     */
+    public function inflectPackageVars($vars)
+    {
+        $vars['name'] = strtolower($vars['name']);
+        $vars['name'] = preg_replace('/.ontowiki$/', '', $vars['name']);
+        $vars['name'] = preg_replace('/-theme$/', '', $vars['name']);
+        $vars['name'] = preg_replace('/-translation$/', '', $vars['name']);
+
+        return $vars;
+    }
+}

--- a/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
+++ b/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace Composer\Installers\Test;
+
+use Composer\Installers\OntoWikiInstaller;
+use Composer\Package\Package;
+use Composer\Composer;
+
+/**
+ * Test for the OntoWikiInstaller
+ * code was taken from DokuWikiInstaller
+ */
+class OntoWikiInstallerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var OntoWikiInstaller
+     */
+    private $installer;
+
+    public function setUp()
+    {
+        $this->installer = new OntoWikiInstaller();
+    }
+
+    /**
+     * @dataProvider packageNameInflectionProvider
+     */
+    public function testInflectPackageVars($type, $name, $expected)
+    {
+        $this->assertEquals(
+            $this->installer->inflectPackageVars(array('name' => $name, 'type'=>$type)),
+            array('name' => $expected, 'type'=>$type)
+        );
+    }
+
+    public function packageNameInflectionProvider()
+    {
+        return array(
+            array(
+                'ontowiki-extension',
+                'CSVImport.ontowiki',
+                'csvimport',
+            ),
+            array(
+                'ontowiki-extension',
+                'csvimport',
+                'csvimport',
+            ),
+            array(
+                'ontowiki-extension',
+                'some_ontowiki_extension',
+                'some_ontowiki_extension',
+            ),
+            array(
+                'ontowiki-extension',
+                'some_ontowiki_extension.ontowiki',
+                'some_ontowiki_extension',
+            ),
+            array(
+                'ontowiki-translation',
+                'de-translation.ontowiki',
+                'de',
+            ),
+            array(
+                'ontowiki-translation',
+                'en-US-translation.ontowiki',
+                'en-us',
+            ),
+            array(
+                'ontowiki-translation',
+                'en-US-translation',
+                'en-us',
+            ),
+            array(
+                'ontowiki-theme',
+                'blue-theme.ontowiki',
+                'blue',
+            ),
+            array(
+                'ontowiki-theme',
+                'blue-theme',
+                'blue',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Add installer for [OntoWiki](http://ontowiki.net/) extensions.

* https://github.com/AKSW/OntoWiki

---------------

- [x] Create class extends `Composer\Installers\BaseInstaller` with your Installer. -> `Composer\Installers\OntoWikiInstaller`
- [x] Create unit tests as a separate class or as part of a `Composer\Installers\Test\InstallerTest`. -> `Composer\Installers\Test\OntoWikiInstallerTest`
- [x] Add information about your Installer in README.md in section "Current Supported Package Types".
- [x] Run the tests. -> OK (345 tests, 376 assertions)

edit: rebase to current upstream master