### PR TITLE
Add moodle-root to custom dependence

### DIFF
--- a/src/Composer/Installers/MoodleInstaller.php
+++ b/src/Composer/Installers/MoodleInstaller.php
@@ -44,6 +44,7 @@ class MoodleInstaller extends BaseInstaller
         'quiz'               => 'mod/quiz/report/{$name}/',
         'report'             => 'report/{$name}/',
         'repository'         => 'repository/{$name}/',
+        'root'               => '{$name}/',
         'scormreport'        => 'mod/scorm/report/{$name}/',
         'search'             => 'search/engine/{$name}/',
         'theme'              => 'theme/{$name}/',


### PR DESCRIPTION
Answer the cases of custom dependencies that need to be in the root directory of Moodle.