### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ git:
   depth: 5
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -93,11 +93,12 @@
         "roundcube/plugin-installer": "*"
     },
     "require": {
+        "php": ">=7.0",
         "composer-plugin-api": "^1.0"
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "~6.4"
     },
     "scripts": {
         "test": "phpunit"

--- a/tests/Composer/Installers/Test/AsgardInstallerTest.php
+++ b/tests/Composer/Installers/Test/AsgardInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\AsgardInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class AsgardInstallerTest extends \PHPUnit_Framework_TestCase
+class AsgardInstallerTest extends TestCase
 {
     /**
      * @var AsgardInstaller

--- a/tests/Composer/Installers/Test/CakePHPInstallerTest.php
+++ b/tests/Composer/Installers/Test/CakePHPInstallerTest.php
@@ -24,7 +24,7 @@ class CakePHPInstallerTest extends TestCase
     public function setUp()
     {
         $this->package = new Package('CamelCased', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\PackageInterface');
         $this->composer = new Composer();
         $this->composer->setConfig(new Config(false));
     }
@@ -65,8 +65,8 @@ class CakePHPInstallerTest extends TestCase
         $package = new RootPackage('CamelCased', '1.0', '1.0');
         $composer = $this->composer;
         $rm = new RepositoryManager(
-            $this->getMock('Composer\IO\IOInterface'),
-            $this->getMock('Composer\Config')
+            $this->createMock('Composer\IO\IOInterface'),
+            $this->createMock('Composer\Config')
         );
         $composer->setRepositoryManager($rm);
         $installer = new CakePHPInstaller($package, $composer);

--- a/tests/Composer/Installers/Test/DokuWikiInstallerTest.php
+++ b/tests/Composer/Installers/Test/DokuWikiInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\DokuWikiInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class DokuWikiInstallerTest extends \PHPUnit_Framework_TestCase
+class DokuWikiInstallerTest extends TestCase
 {
     /**
      * @var DokuWikiInstaller

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -45,13 +45,11 @@ class InstallerTest extends TestCase
             ),
         ));
 
-        $this->dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->dm = $this->createMock('Composer\Downloader\DownloadManager');
         $this->composer->setDownloadManager($this->dm);
 
-        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->repository = $this->createMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->io = $this->createMock('Composer\IO\IOInterface');
     }
 
     /**
@@ -540,10 +538,10 @@ class InstallerTest extends TestCase
     {
         $package = new Package('foo', '1.0.0', '1.0.0');
 
-        $installer = $this->getMock('Composer\Installers\Installer', array('getInstallPath'), array($this->io, $this->composer));
+        $installer = $this->createPartialMock('Composer\Installers\Installer', array('getInstallPath'), array($this->io, $this->composer));
         $installer->expects($this->atLeastOnce())->method('getInstallPath')->with($package)->will($this->returnValue(sys_get_temp_dir().'/foo'));
 
-        $repo = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $repo = $this->createMock('Composer\Repository\InstalledRepositoryInterface');
         $repo->expects($this->once())->method('hasPackage')->with($package)->will($this->returnValue(true));
         $repo->expects($this->once())->method('removePackage')->with($package);
 

--- a/tests/Composer/Installers/Test/MayaInstallerTest.php
+++ b/tests/Composer/Installers/Test/MayaInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\MayaInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class MayaInstallerTest extends \PHPUnit_Framework_TestCase
+class MayaInstallerTest extends TestCase
 {
     /**
      * @var MayaInstaller

--- a/tests/Composer/Installers/Test/MediaWikiInstallerTest.php
+++ b/tests/Composer/Installers/Test/MediaWikiInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\MediaWikiInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class MediaWikiInstallerTest extends \PHPUnit_Framework_TestCase
+class MediaWikiInstallerTest extends TestCase
 {
     /**
      * @var MediaWikiInstaller

--- a/tests/Composer/Installers/Test/OctoberInstallerTest.php
+++ b/tests/Composer/Installers/Test/OctoberInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\OctoberInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class OctoberInstallerTest extends \PHPUnit_Framework_TestCase
+class OctoberInstallerTest extends TestCase
 {
     /**
      * @var OctoberInstaller

--- a/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
+++ b/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
@@ -2,6 +2,7 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\OntoWikiInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
@@ -9,7 +10,7 @@ use Composer\Composer;
  * Test for the OntoWikiInstaller
  * code was taken from DokuWikiInstaller
  */
-class OntoWikiInstallerTest extends \PHPUnit_Framework_TestCase
+class OntoWikiInstallerTest extends TestCase
 {
     /**
      * @var OntoWikiInstaller

--- a/tests/Composer/Installers/Test/PimcoreInstallerTest.php
+++ b/tests/Composer/Installers/Test/PimcoreInstallerTest.php
@@ -18,7 +18,7 @@ class PimcoreInstallerTest extends TestCase
     public function setUp()
     {
         $this->package = new Package('CamelCased', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\PackageInterface');
         $this->composer = new Composer();
     }
 

--- a/tests/Composer/Installers/Test/PiwikInstallerTest.php
+++ b/tests/Composer/Installers/Test/PiwikInstallerTest.php
@@ -36,7 +36,7 @@ class PiwikInstallerTest extends TestCase
     public function setUp()
     {
         $this->package = new Package('VisitSummary', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\PackageInterface');
         $this->composer = new Composer();
     }
 

--- a/tests/Composer/Installers/Test/SyDESInstallerTest.php
+++ b/tests/Composer/Installers/Test/SyDESInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\SyDESInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class SyDESInstallerTest extends \PHPUnit_Framework_TestCase
+class SyDESInstallerTest extends TestCase
 {
     /**
      * @var SyDESInstaller

--- a/tests/Composer/Installers/Test/TestCase.php
+++ b/tests/Composer/Installers/Test/TestCase.php
@@ -14,11 +14,12 @@ namespace Composer\Installers\Test;
 
 use Composer\Package\Version\VersionParser;
 use Composer\Package\Package;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Composer\Package\AliasPackage;
 use Composer\Package\LinkConstraint\VersionConstraint;
 use Composer\Util\Filesystem;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     private static $parser;
 

--- a/tests/Composer/Installers/Test/VgmcpInstallerTest.php
+++ b/tests/Composer/Installers/Test/VgmcpInstallerTest.php
@@ -2,10 +2,11 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\VgmcpInstaller;
+use PHPUnit\Framework\TestCase;
 use Composer\Package\Package;
 use Composer\Composer;
 
-class VgmcpInstallerTest extends \PHPUnit_Framework_TestCase
+class VgmcpInstallerTest extends TestCase
 {
     /**
      * @var VgmcpInstaller

--- a/tests/Composer/Installers/Test/YawikInstallerTest.php
+++ b/tests/Composer/Installers/Test/YawikInstallerTest.php
@@ -36,7 +36,7 @@ class YawikInstallerTest extends TestCase
     public function setUp()
     {
         $this->package = new Package('YawikCompanyRegistration', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->io = $this->getMockBuilder('Composer\IO\PackageInterface');
         $this->composer = new Composer();
     }
 


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to PHP `5.4`, `5.5`, `5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).

I used [this article](https://thephp.cc/news/2017/02/migrating-to-phpunit-6) from @sebastianbergmann to help me.

PS: There's this `Composer\Installers\Test\InstallerTest::testUninstallAndDeletePackageFromLocalRepo
` test that isn't working, but I couldn't figure out what's happening :cry: 