### PR TITLE
Add support for SiteDirect modules and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ is not needed to install packages with these frameworks:
 | Roundcube    | `roundcube-plugin`
 | shopware     | `shopware-backend-plugin`<br/>`shopware-core-plugin`<br/>`shopware-frontend-plugin`<br/>`shopware-theme`<br/>`shopware-plugin`<br/>`shopware-frontend-theme`
 | SilverStripe | `silverstripe-module`<br>`silverstripe-theme`
+| SiteDirect   | `sitedirect-module`<br>`sitedirect-plugin`
 | SMF          | `smf-module`<br>`smf-theme`
 | SyDES        | `sydes-module`<br>`sydes-theme`
 | symfony1     | **`symfony1-plugin`**

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -83,6 +83,7 @@ class Installer extends LibraryInstaller
         'reindex'      => 'ReIndexInstaller',
         'roundcube'    => 'RoundcubeInstaller',
         'shopware'     => 'ShopwareInstaller',
+        'sitedirect'   => 'SiteDirectInstaller',
         'silverstripe' => 'SilverStripeInstaller',
         'smf'          => 'SMFInstaller',
         'sydes'        => 'SyDESInstaller',

--- a/src/Composer/Installers/SiteDirectInstaller.php
+++ b/src/Composer/Installers/SiteDirectInstaller.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Composer\Installers;
+
+class SiteDirectInstaller extends BaseInstaller
+{
+    protected $locations = [
+        'module' => 'modules/{$vendor}/{$name}/',
+        'plugin' => 'plugins/{$vendor}/{$name}/'
+    ];
+
+    public function inflectPackageVars($vars)
+    {
+        return $this->parseVars($vars);
+    }
+
+    protected function parseVars($vars)
+    {
+        $vars['vendor'] = strtolower($vars['vendor']) == 'sitedirect' ? 'SiteDirect' : $vars['vendor'];
+        $vars['name'] = str_replace(array('-', '_'), ' ', $vars['name']);
+        $vars['name'] = str_replace(' ', '', ucwords($vars['name']));
+
+        return $vars;
+    }
+}

--- a/tests/Composer/Installers/Test/SiteDirectInstallerTest.php
+++ b/tests/Composer/Installers/Test/SiteDirectInstallerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Composer\Installers\Test;
+
+use Composer\Composer;
+use Composer\Installers\SiteDirectInstaller;
+use Composer\Package\Package;
+
+class SiteDirectInstallerTest extends TestCase
+{
+    /** @var SiteDirectInstaller $installer */
+    protected $installer;
+
+    /** @var Package */
+    private $package;
+
+    public function SetUp()
+    {
+        $this->package = new Package('sitedirect/some_name', '1.0.9', '1.0');
+        $this->installer = new SiteDirectInstaller(
+            $this->package,
+            new Composer()
+        );
+
+    }
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testInflectPackageVars($data, $expected)
+    {
+        $result = $this->installer->inflectPackageVars($data);
+        $this->assertEquals($result, $expected);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testInstallPath($data, $expected)
+    {
+        $result = $this->installer->inflectPackageVars($data);
+        $path = $this->createPackage($data);
+
+        // use $result to get the proper capitalization for the vendor path
+        $expectedPath = "modules/{$result['vendor']}/{$result['name']}/";
+        $notExpectedPath = "modules/{$data['vendor']}/{$data['name']}/";
+        $this->assertEquals($expectedPath, $path);
+        $this->assertNotEquals($notExpectedPath, $path);
+    }
+
+    /**
+     * @param $data
+     * @return string
+     */
+    private function createPackage($data)
+    {
+        $fullName = "{$data['vendor']}/{$data['name']}";
+
+        $package = new Package($fullName, '1.0', '1.0');
+        $package->setType('sitedirect-module');
+        $installer = new SiteDirectInstaller($package, new Composer());
+
+        $path = $installer->getInstallPath($package, 'sitedirect');
+        return $path;
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [
+                'data' => [
+                    'name' => 'kernel',
+                    'vendor' => 'sitedirect',
+                    'type'   => 'sitedirect-module',
+                ],
+                'expected' => [
+                    'name' => 'Kernel',
+                    'vendor' => 'SiteDirect',
+                    'type' => 'sitedirect-module',
+                ]
+            ],
+            [
+                'data' => [
+                    'name' => 'that_guy',
+                    'vendor' => 'whatGuy',
+                    'type' => 'sitedirect-module',
+                ],
+                'expected' => [
+                    'name' => 'ThatGuy',
+                    'vendor' => 'whatGuy',
+                    'type' => 'sitedirect-module',
+                ]
+            ],
+            [
+                'data' => [
+                    'name' => 'checkout',
+                    'vendor' => 'someVendor',
+                    'type' => 'sitedirect-plugin',
+                ],
+                'expected' => [
+                    'name' => 'Checkout',
+                    'vendor' => 'someVendor',
+                    'type' => 'sitedirect-plugin',
+                ]
+            ],
+            [
+                'data' => [
+                    'name' => 'checkout',
+                    'vendor' => 'siteDirect',
+                    'type' => 'sitedirect-plugin',
+                ],
+                'expected' => [
+                    'name' => 'Checkout',
+                    'vendor' => 'SiteDirect',
+                    'type' => 'sitedirect-plugin',
+                ]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Over at SiteDirect we made the decision to make modules and plugins composer compatible.
Therefor we would like to type them sitedirect-module and -plugin to be able to handle them according to the structure that we've set up to use.