### PR TITLE
Support optional prefix in OctoberCMS installers

### DIFF
--- a/src/Composer/Installers/OctoberInstaller.php
+++ b/src/Composer/Installers/OctoberInstaller.php
@@ -39,7 +39,7 @@ class OctoberInstaller extends BaseInstaller
 
     protected function inflectThemeVars($vars)
     {
-        $vars['name'] = preg_replace('/^oc-|-theme/', '', $vars['name']);
+        $vars['name'] = preg_replace('/^oc-|-theme$/', '', $vars['name']);
 
         return $vars;
     }

--- a/src/Composer/Installers/OctoberInstaller.php
+++ b/src/Composer/Installers/OctoberInstaller.php
@@ -32,14 +32,14 @@ class OctoberInstaller extends BaseInstaller
 
     protected function inflectPluginVars($vars)
     {
-        $vars['name'] = preg_replace('/-plugin$/', '', $vars['name']);
+        $vars['name'] = preg_replace('/^oc-|-plugin$/', '', $vars['name']);
 
         return $vars;
     }
 
     protected function inflectThemeVars($vars)
     {
-        $vars['name'] = preg_replace('/-theme$/', '', $vars['name']);
+        $vars['name'] = preg_replace('/^oc-|-theme/', '', $vars['name']);
 
         return $vars;
     }


### PR DESCRIPTION
OctoberCMS plugins and themes can have an optional `oc-` prefix, this adds support for packages that utilize the optional prefix. See http://octobercms.com/help/guidelines/developer#repository-naming