### PR TITLE
[CS] Clean elses

### DIFF
--- a/src/Composer/Installers/ShopwareInstaller.php
+++ b/src/Composer/Installers/ShopwareInstaller.php
@@ -25,9 +25,9 @@ class ShopwareInstaller extends BaseInstaller
     {
         if ($vars['type'] === 'shopware-theme') {
             return $this->correctThemeName($vars);
-        } else {
-            return $this->correctPluginName($vars);
         }
+
+        return $this->correctPluginName($vars);        
     }
 
     /**

--- a/src/Composer/Installers/SilverStripeInstaller.php
+++ b/src/Composer/Installers/SilverStripeInstaller.php
@@ -28,9 +28,8 @@ class SilverStripeInstaller extends BaseInstaller
             && version_compare($package->getVersion(), '2.999.999') < 0
         ) {
             return $this->templatePath($this->locations['module'], array('name' => 'sapphire'));
-        } else {
-            return parent::getInstallPath($package, $frameworkType);
         }
 
+        return parent::getInstallPath($package, $frameworkType);
     }
 }


### PR DESCRIPTION
I've cleaned the `else`s when we have already returned something, this saves us some lines of code :put_litter_in_its_place:

[`PHP-CS-Fixes`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.