### PR TITLE
[CS] Remove unused imports

### DIFF
--- a/src/Composer/Installers/CakePHPInstaller.php
+++ b/src/Composer/Installers/CakePHPInstaller.php
@@ -2,7 +2,6 @@
 namespace Composer\Installers;
 
 use Composer\DependencyResolver\Pool;
-use Composer\Package\PackageInterface;
 
 class CakePHPInstaller extends BaseInstaller
 {

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -4,7 +4,6 @@ namespace Composer\Installers;
 use Composer\IO\IOInterface;
 use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
-use Composer\Downloader\DownloadManager;
 use Composer\Repository\InstalledRepositoryInterface;
 
 class Installer extends LibraryInstaller

--- a/tests/Composer/Installers/Test/BitrixInstallerTest.php
+++ b/tests/Composer/Installers/Test/BitrixInstallerTest.php
@@ -3,7 +3,6 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\BitrixInstaller;
-use Composer\Package\PackageInterface;
 use Composer\Package\Package;
 use Composer\Composer;
 

--- a/tests/Composer/Installers/Test/CakePHPInstallerTest.php
+++ b/tests/Composer/Installers/Test/CakePHPInstallerTest.php
@@ -6,7 +6,6 @@ use Composer\Repository\RepositoryManager;
 use Composer\Repository\InstalledArrayRepository;
 use Composer\Package\Package;
 use Composer\Package\RootPackage;
-use Composer\Package\Link;
 use Composer\Package\Version\VersionParser;
 use Composer\Composer;
 use Composer\Config;

--- a/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
+++ b/tests/Composer/Installers/Test/OntoWikiInstallerTest.php
@@ -2,8 +2,6 @@
 namespace Composer\Installers\Test;
 
 use Composer\Installers\OntoWikiInstaller;
-use Composer\Package\Package;
-use Composer\Composer;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**


### PR DESCRIPTION
I've removed some unused imports. This save us some lines :put_litter_in_its_place: 

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.