### PR TITLE
Added installer for myty modules and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ is not needed to install packages with these frameworks:
 | MODX         | `modx-extra`
 | MODX Evo     | `modxevo-snippet`<br>`modxevo-plugin`<br>`modxevo-module`<br>`modxevo-template`<br>`modxevo-lib`
 | MediaWiki    | `mediawiki-extension`
+| Myty         | `myty-module`<br>`myty-project`
 | October      | **`october-module`<br>`october-plugin`<br>`october-theme`**
 | OntoWiki     | `ontowiki-extension`<br>`ontowiki-theme`<br>`ontowiki-translation`
 | OXID         | `oxid-module`<br>`oxid-theme`<br>`oxid-out`

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "MODX",
         "MODX Evo",
         "MediaWiki",
+        "Myty",
         "OXID",
         "osclass",
         "MODULEWork",

--- a/src/Composer/Installers/MytyInstaller.php
+++ b/src/Composer/Installers/MytyInstaller.php
@@ -6,7 +6,6 @@ namespace Composer\Installers;
  * Myty is a closed source CMF/CMS developed by tyclipso.net since 2003
  * @see https://myty.readme.io
  * @see https://tyclipso.net
- * @author Mike Reiche <mike.reiche@tyclipso.net>
  */
 class MytyInstaller extends BaseInstaller
 {

--- a/src/Composer/Installers/MytyInstaller.php
+++ b/src/Composer/Installers/MytyInstaller.php
@@ -11,7 +11,8 @@ class MytyInstaller extends BaseInstaller
 {
     // Myty composer components are located in DocRoot/3rdParty
     protected $locations = array(
-        'project' => '../projects/{$name}/',
-        'module'   => '../tycon/modules/{$name}/'
+        'base' => 'tycon/',
+        'project' => 'projects/{$name}/',
+        'module'   => 'tycon/modules/{$name}/'
     );
 }

--- a/src/Composer/Installers/MytyInstaller.php
+++ b/src/Composer/Installers/MytyInstaller.php
@@ -1,0 +1,18 @@
+<?php
+namespace Composer\Installers;
+
+/**
+ * Composer installer for myty projects and modules.
+ * Myty is a closed source CMF/CMS developed by tyclipso.net since 2003
+ * @see https://myty.readme.io
+ * @see https://tyclipso.net
+ * @author Mike Reiche <mike.reiche@tyclipso.net>
+ */
+class MytyInstaller extends BaseInstaller
+{
+    // Myty composer components are located in DocRoot/3rdParty
+    protected $locations = array(
+        'project' => '../projects/{$name}/',
+        'module'   => '../tycon/modules/{$name}/'
+    );
+}


### PR DESCRIPTION
I've added an installer for myty modules and projects.
Im not sure, if I've done this right. I just copied an existing installer and changed name and pathes. I couldn't get this installer to work when copying it to the installers source directory. But I followed the instructions in `CONTRIBUTING.md`.

The supported names are:

* myty-module
* myty-project