### PR TITLE
Normalise vendor directory containing hyphen

### DIFF
--- a/src/Composer/Installers/OctoberInstaller.php
+++ b/src/Composer/Installers/OctoberInstaller.php
@@ -33,6 +33,7 @@ class OctoberInstaller extends BaseInstaller
     protected function inflectPluginVars($vars)
     {
         $vars['name'] = preg_replace('/^oc-|-plugin$/', '', $vars['name']);
+        $vars['vendor'] = preg_replace('/[^a-z0-9_]/i', '', $vars['vendor']);
 
         return $vars;
     }

--- a/tests/Composer/Installers/Test/OctoberInstallerTest.php
+++ b/tests/Composer/Installers/Test/OctoberInstallerTest.php
@@ -24,11 +24,15 @@ class OctoberInstallerTest extends BaseTestCase
     /**
      * @dataProvider packageNameInflectionProvider
      */
-    public function testInflectPackageVars($type, $name, $expected)
+    public function testInflectPackageVars($type, $vendor, $name, $expectedVendor, $expectedName)
     {
         $this->assertEquals(
-            $this->installer->inflectPackageVars(array('name' => $name, 'type' => $type)),
-            array('name' => $expected, 'type' => $type)
+            $this->installer->inflectPackageVars(array(
+                'vendor' => $vendor,
+                'name' => $name,
+                'type' => $type
+            )),
+            array('vendor' => $expectedVendor, 'name' => $expectedName, 'type' => $type)
         );
     }
 
@@ -37,29 +41,47 @@ class OctoberInstallerTest extends BaseTestCase
         return array(
             array(
                 'october-plugin',
+                'acme',
                 'subpagelist',
+                'acme',
                 'subpagelist',
             ),
             array(
                 'october-plugin',
+                'acme',
                 'subpagelist-plugin',
+                'acme',
                 'subpagelist',
             ),
             array(
                 'october-plugin',
+                'acme',
                 'semanticoctober',
+                'acme',
                 'semanticoctober',
+            ),
+            // tests vendor name containing a hyphen
+            array(
+                'october-plugin',
+                'foo-bar-co',
+                'blog',
+                'foobarco',
+                'blog'
             ),
             // tests that exactly one '-theme' is cut off
             array(
                 'october-theme',
+                'acme',
                 'some-theme-theme',
+                'acme',
                 'some-theme',
             ),
             // tests that names without '-theme' suffix stay valid
             array(
                 'october-theme',
+                'acme',
                 'someothertheme',
+                'acme',
                 'someothertheme',
             ),
         );


### PR DESCRIPTION
Vendors on Packagist are allowed a hyphen in their name (such as
https://packagist.org/packages/grrr-amsterdam/). However, when
translating this directory structure into a PHP namespace, it will
result in an illegal namespace.

This update removes anything from the vendor name that's not
alphanumeric or an underscore.