### PR TITLE
Deprecated Pimcore

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ is not needed to install packages with these frameworks:
 | Moodle       | `moodle-*` (Please [check source](https://raw.githubusercontent.com/composer/installers/master/src/Composer/Installers/MoodleInstaller.php) for all supported types)
 | Piwik        | `piwik-plugin`
 | phpBB        | `phpbb-extension`<br>`phpbb-style`<br>`phpbb-language`
-| Pimcore      | `pimcore-plugin`
+| Pimcore      | `pimcore-plugin`(deprecated, only used for versions <= 4) 
 | Plentymarkets      | `plentymarkets-plugin`
 | PPI          | **`ppi-module`**
 | Puppet       | `puppet-module`


### PR DESCRIPTION
Pimcore 5 doesn't use custom install directories anymore, so this is deprecated. 