### PR TITLE
Update README to add note about ordering of custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ using the `vendor:` prefix.
 These would use your custom path for each of the listed packages. The available
 variables to use in your paths are: `{$name}`, `{$vendor}`, `{$type}`.
 
+Note that paths are matched based on the first path that matches in the list.
+So list position of custom path may make a difference.
+
 ## Custom Install Names
 
 If you're a package author and need your package to be named differently when


### PR DESCRIPTION
This PR updates the README.md to include a note about ordering of Custom Paths. While creating a custom path today I noticed the following. 

The following ordering doesn't work to change the directory for `npm-asset/intl-tel-input`

        `"installer-paths": {
            "web/core": ["type:drupal-core"],
            "web/libraries/{$name}": [
                "type:drupal-library",
                "type:bower-asset",
                "type:npm-asset"
            ],
            "web/modules/contrib/{$name}": ["type:drupal-module"],
            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
            "web/themes/contrib/{$name}": ["type:drupal-theme"],
            "drush/contrib/{$name}": ["type:drupal-drush"]
            "web/libraries/jquery.{$name}": [
                "npm-asset/intl-tel-input"
            ],
        },`

However, If I move it up in the list it works perfectly. 

        `"installer-paths": {
            "web/core": ["type:drupal-core"],
            "web/libraries/jquery.{$name}": [
                "npm-asset/intl-tel-input"
            ],
            "web/libraries/{$name}": [
                "type:drupal-library",
                "type:bower-asset",
                "type:npm-asset"
            ],
            "web/modules/contrib/{$name}": ["type:drupal-module"],
            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
            "web/themes/contrib/{$name}": ["type:drupal-theme"],
            "drush/contrib/{$name}": ["type:drupal-drush"]
        },`