### PR TITLE
Added new type - component that can be installer into MODX instance

### DIFF
--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -68,7 +68,7 @@ class Installer extends LibraryInstaller
         'mediawiki'    => 'MediaWikiInstaller',
         'microweber'   => 'MicroweberInstaller',
         'modulework'   => 'MODULEWorkInstaller',
-        'modx'         => 'ModxInstaller',
+        'modx'         => 'MODXInstaller',
         'modxevo'      => 'MODXEvoInstaller',
         'moodle'       => 'MoodleInstaller',
         'october'      => 'OctoberInstaller',

--- a/src/Composer/Installers/MODXInstaller.php
+++ b/src/Composer/Installers/MODXInstaller.php
@@ -4,9 +4,10 @@ namespace Composer\Installers;
 /**
  * An installer to handle MODX specifics when installing packages.
  */
-class ModxInstaller extends BaseInstaller
+class MODXInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'extra' => 'core/packages/{$name}/'
+        'extra' => 'core/packages/{$name}/',
+        'component' => '{$name}'
     );
 }


### PR DESCRIPTION
It will allow installing some core components like `setup` (https://github.com/modxcms/revolution/tree/3.x/setup), using Composer.

Also, I've changed the name of Modx to popper MODX.