### PR TITLE
Installer for TAO extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ is not needed to install packages with these frameworks:
 | SMF          | `smf-module`<br>`smf-theme`
 | SyDES        | `sydes-module`<br>`sydes-theme`
 | symfony1     | **`symfony1-plugin`**
+| TAO          | `tao-extension`
 | Tusk         | `tusk-task`<br>`tusk-command`<br>`tusk-asset`
 | TYPO3 Flow   | `typo3-flow-package`<br>`typo3-flow-framework`<br>`typo3-flow-plugin`<br>`typo3-flow-site`<br>`typo3-flow-boilerplate`<br>`typo3-flow-build`
 | TYPO3 CMS    | `typo3-cms-extension` (Deprecated in this package, use the [TYPO3 CMS Installers](https://packagist.org/packages/typo3/cms-composer-installers) instead)

--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -94,6 +94,7 @@ class Installer extends LibraryInstaller
         'smf'          => 'SMFInstaller',
         'sydes'        => 'SyDESInstaller',
         'symfony1'     => 'Symfony1Installer',
+        'tao'          => 'TaoInstaller',
         'thelia'       => 'TheliaInstaller',
         'tusk'         => 'TuskInstaller',
         'typo3-cms'    => 'TYPO3CmsInstaller',

--- a/src/Composer/Installers/TaoInstaller.php
+++ b/src/Composer/Installers/TaoInstaller.php
@@ -1,0 +1,12 @@
+<?php
+namespace Composer\Installers;
+
+/**
+ * An installer to handle TAO extensions.
+ */
+class TaoInstaller extends BaseInstaller
+{
+    protected $locations = array(
+        'extension' => '{$name}'
+    );
+}


### PR DESCRIPTION
In TAO (https://www.taotesting.com/) we install extensions into the root folder (by current architecture) that requires a custom plugin to handle it (https://github.com/oat-sa/oatbox-extension-installer).

This pull request created with a goal to move existing way to more modern with the usage of `composer/installer`.