### PR TITLE
Changing plugin file location

### DIFF
--- a/src/Composer/Installers/CraftInstaller.php
+++ b/src/Composer/Installers/CraftInstaller.php
@@ -10,7 +10,7 @@ class CraftInstaller extends BaseInstaller
     const NAME_SUFFIX = 'plugin';
 
     protected $locations = array(
-        'plugin' => 'craft/plugins/{$name}/',
+        'plugin' => 'vendor/{$name}/',
     );
 
     /**


### PR DESCRIPTION
With Craft 3, plugins added via composer live in /vendor, not `/craft/plugins` so some installs are failing. This change for Craft 3 users will clear the problem up.