### PR TITLE
Update TAO Installer for proper work

### DIFF
--- a/src/Composer/Installers/TaoInstaller.php
+++ b/src/Composer/Installers/TaoInstaller.php
@@ -6,7 +6,25 @@ namespace Composer\Installers;
  */
 class TaoInstaller extends BaseInstaller
 {
+    const EXTRA_TAO_EXTENSION_NAME = 'tao-extension-name';
+
     protected $locations = array(
         'extension' => '{$name}'
     );
+    
+    public function inflectPackageVars($vars)
+    {
+        $extra = $this->package->getExtra();
+
+        if (array_key_exists(self::EXTRA_TAO_EXTENSION_NAME, $extra)) {
+            $vars['name'] = $extra[self::EXTRA_TAO_EXTENSION_NAME];
+            return $vars;
+        }
+
+        $vars['name'] = str_replace('extension-', '', $vars['name']);
+        $vars['name'] = str_replace('-', ' ', $vars['name']);
+        $vars['name'] = lcfirst(str_replace(' ', '', ucwords($vars['name'])));
+
+        return $vars;
+    }
 }


### PR DESCRIPTION
It adds additional manipulations with a name to fit naming template.

In current implementation extension name set in `extra` fields so this changes respect this value at first and after default rule will be applied.