### PR TITLE
Allow a single installer path to be declared as a string

### DIFF
--- a/src/Composer/Installers/BaseInstaller.php
+++ b/src/Composer/Installers/BaseInstaller.php
@@ -126,6 +126,7 @@ abstract class BaseInstaller
     protected function mapCustomInstallPaths(array $paths, $name, $type, $vendor = NULL)
     {
         foreach ($paths as $path => $names) {
+            $names = (array) $names;
             if (in_array($name, $names) || in_array('type:' . $type, $names) || in_array('vendor:' . $vendor, $names)) {
                 return $path;
             }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -554,6 +554,23 @@ class InstallerTest extends TestCase
     }
 
     /**
+     * testStringPath
+     */
+    public function testStringPath()
+    {
+        $installer = new Installer($this->io, $this->composer);
+        $package = new Package('penyaskito/my_module', '1.0.0', '1.0.0');
+        $package->setType('drupal-module');
+        $this->composer->getPackage()->setExtra(array(
+          'installer-paths' => array(
+            'modules/custom/{$name}/' => 'vendor:penyaskito',
+          ),
+        ));
+        $result = $installer->getInstallPath($package);
+        $this->assertEquals('modules/custom/my_module/', $result);
+    }
+
+    /**
      * testNoVendorName
      */
     public function testNoVendorName()


### PR DESCRIPTION
Currently when you declare an installer path as a string versus an array, i.e. something like:
```json
        "installer-paths": {
            "web/modules/{$name}": "type:drupal-module",
        }
```
you get an error:

> in_array() expects parameter 2 to be array, string given
/home/tobias/Projekte/installers/src/Composer/Installers/BaseInstaller.php:130
/home/tobias/Projekte/installers/src/Composer/Installers/BaseInstaller.php:58
/home/tobias/Projekte/installers/src/Composer/Installers/Installer.php:158

I would like this to be possible. Not because I have a problem with the array structure in general, but because I would like to be able to configure the installer paths via the `composer config` command-line and that only allows 3 levels of nesting. I.e. I would like to be able to run
```
composer config extra.installer-paths.web/modules/{\$name} type:drupal-module
```
without that breaking the configuration.

Because a very common configuration is to have only a single path anyway, it seems like it is not a huge divergence from the status quo.

And it seemed easy enough to implement without adding much complexity. Also added a test and verified locally that it triggers the notice above without the fix.

Thoughts?