### PR TITLE
Allow mautic-core to also be placed in order to allow the vendor folder to live outside of the public mautic folder

### DIFF
--- a/src/Composer/Installers/MauticInstaller.php
+++ b/src/Composer/Installers/MauticInstaller.php
@@ -4,6 +4,7 @@ namespace Composer\Installers;
 class MauticInstaller extends BaseInstaller
 {
     protected $locations = array(
+        'core'   => 'public/',
         'plugin' => 'plugins/{$name}/',
         'theme' => 'themes/{$name}/',
     );


### PR DESCRIPTION
As the title says, let's support mautic-core as a type so we can do a similar workflow as is happening with drupal-core.