### PR TITLE
Add PreRemoveDisabledInstallersEvent

### DIFF
--- a/src/Composer/Installers/Installer.php
+++ b/src/Composer/Installers/Installer.php
@@ -260,6 +260,13 @@ class Installer extends LibraryInstaller
      */
     protected function removeDisabledInstallers()
     {
+        // Let plugins change the package's extra section before processing
+        $event = new PreRemoveDisabledInstallersEvent(
+            InstallerEvents::PRE_REMOVE_DISABLED_INSTALLERS,
+            $this->composer->getPackage()
+        );
+        $this->composer->getEventDispatcher()->dispatch($event->getName(), $event);
+
         $extra = $this->composer->getPackage()->getExtra();
 
         if (!isset($extra['installer-disable']) || $extra['installer-disable'] === false) {

--- a/src/Composer/Installers/InstallerEvents.php
+++ b/src/Composer/Installers/InstallerEvents.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installers;
+
+/**
+ * The Installer Events.
+ *
+ * @author Simon Gilli <composer@gilbertsoft.org>
+ */
+class InstallerEvents
+{
+    /**
+     * The PRE_REMOVE_DISABLED_INSTALLERS event occurs before the disabled
+     * installers gets removed and lets you modify the root package if needed.
+     *
+     * The event listener method receives a
+     * Composer\Installers\PreRemoveDisabledInstallersEvent instance.
+     *
+     * @var string
+     */
+    const PRE_REMOVE_DISABLED_INSTALLERS = 'pre-remove-disabled-installers';
+}

--- a/src/Composer/Installers/PreRemoveDisabledInstallersEvent.php
+++ b/src/Composer/Installers/PreRemoveDisabledInstallersEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Installers;
+
+use Composer\EventDispatcher\Event;
+use Composer\Package\RootPackageInterface;
+
+/**
+ * The pre remove disabled installers event.
+ *
+ * @author Simon Gilli <composer@gilbertsoft.org>
+ */
+class PreRemoveDisabledInstallersEvent extends Event
+{
+    /**
+     * @var RootPackageInterface
+     */
+    private $package;
+
+    /**
+     * Constructor.
+     *
+     * @param string               $name    The event name
+     * @param RootPackageInterface $package The root package
+     */
+    public function __construct($name, RootPackageInterface $package)
+    {
+        parent::__construct($name);
+        $this->package = $package;
+    }
+
+    /**
+     * Returns the package
+     *
+     * @return RootPackageInterface
+     */
+    public function getPackage()
+    {
+        return $this->package;
+    }
+}

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -32,6 +32,9 @@ class InstallerTest extends TestCase
         $this->config = new Config();
         $this->composer->setConfig($this->config);
 
+        $eventDispatcher = $this->getMockBuilder('Composer\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
+        $this->composer->setEventDispatcher($eventDispatcher);
+
         $this->vendorDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'baton-test-vendor';
         $this->ensureDirectoryExistsAndClear($this->vendorDir);
 


### PR DESCRIPTION
This new event introduces the possibility for composer plugins to modify the root package, especially the extra section, before the disabled installers get removed.

We also get rid of the long term issue having with the integrated TYPO3 installer which is deprecated since 2016 see also #281 and #300. Afterwards the TYPO3 Core Team is able to disable the here included installer with the core's provided package typo3/cms-composer-installers and so we not longer have conflicts here see https://github.com/TYPO3/CmsComposerInstallers/issues/108.

### Pending tasks
- [ ] add tests
- [ ] add documentation