### PR TITLE
Update MauticInstaller to allow plugins & themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ is not needed to install packages with these frameworks:
 | majima       | `majima-plugin`
 | Mako         | `mako-package`
 | MantisBT     | `mantisbt-plugin`
-| Mautic       | `mautic-plugin`<br>`mautic-theme`
+| Mautic       | `mautic-core`<br>`mautic-plugin`<br>`mautic-theme`
 | Maya         | `maya-module`
 | MODX         | `modx-extra`
 | MODX Evo     | `modxevo-snippet`<br>`modxevo-plugin`<br>`modxevo-module`<br>`modxevo-template`<br>`modxevo-lib`

--- a/src/Composer/Installers/MauticInstaller.php
+++ b/src/Composer/Installers/MauticInstaller.php
@@ -1,22 +1,45 @@
 <?php
 namespace Composer\Installers;
 
+use Composer\Package\PackageInterface;
+
 class MauticInstaller extends BaseInstaller
 {
     protected $locations = array(
-        'plugin' => 'plugins/{$name}/',
-        'theme' => 'themes/{$name}/',
+        'plugin'           => 'plugins/{$name}/',
+        'theme'            => 'themes/{$name}/',
+        'core'             => 'app/',
     );
+
+    private function getDirectoryName()
+    {
+        $extra = $this->package->getExtra();
+        if (!empty($extra['install-directory-name'])) {
+            return $extra['install-directory-name'];
+        }
+
+        return $this->toCamelCase($this->package->getPrettyName());
+    }
+
+    /**
+     * @param string $packageName
+     *
+     * @return string
+     */
+    private function toCamelCase($packageName)
+    {
+        return str_replace(' ', '', ucwords(str_replace('-', ' ', basename($packageName))));
+    }
 
     /**
      * Format package name of mautic-plugins to CamelCase
      */
     public function inflectPackageVars($vars)
     {
+
         if ($vars['type'] == 'mautic-plugin') {
-            $vars['name'] = preg_replace_callback('/(-[a-z])/', function ($matches) {
-                return strtoupper($matches[0][1]);
-            }, ucfirst($vars['name']));
+            $directoryName = $this->getDirectoryName($vars['name']);
+            $vars['name'] = $directoryName;
         }
 
         return $vars;

--- a/src/Composer/Installers/MauticInstaller.php
+++ b/src/Composer/Installers/MauticInstaller.php
@@ -37,7 +37,7 @@ class MauticInstaller extends BaseInstaller
     public function inflectPackageVars($vars)
     {
 
-        if ($vars['type'] == 'mautic-plugin') {
+        if ($vars['type'] == 'mautic-plugin' || $vars['type'] == 'mautic-theme') {
             $directoryName = $this->getDirectoryName();
             $vars['name'] = $directoryName;
         }

--- a/src/Composer/Installers/MauticInstaller.php
+++ b/src/Composer/Installers/MauticInstaller.php
@@ -38,7 +38,7 @@ class MauticInstaller extends BaseInstaller
     {
 
         if ($vars['type'] == 'mautic-plugin') {
-            $directoryName = $this->getDirectoryName($vars['name']);
+            $directoryName = $this->getDirectoryName();
             $vars['name'] = $directoryName;
         }
 

--- a/tests/Composer/Installers/Test/MauticInstallerTest.php
+++ b/tests/Composer/Installers/Test/MauticInstallerTest.php
@@ -4,14 +4,18 @@ namespace Composer\Installers\Test;
 use Composer\Installers\MauticInstaller;
 use Composer\Package\Package;
 use Composer\Composer;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class MauticInstallerTest extends BaseTestCase
+class MauticInstallerTest extends TestCase
 {
     /**
      * @var MauticInstaller
      */
     private $installer;
+
+    /**
+     * @var \Composer\Composer
+     */
+    protected $composer;
 
     public function setUp()
     {
@@ -31,7 +35,7 @@ class MauticInstallerTest extends BaseTestCase
         $package = new Package($vars['name'], '1.0.0', '1.0.0');
         $package->setType($vars['type']);
         if (isset($vars['extra'])) {
-            $package->setExtra($vars['extra']);
+            $package->setExtra((array) $vars['extra']);
         }
 
         $installer = new MauticInstaller(
@@ -69,16 +73,16 @@ class MauticInstallerTest extends BaseTestCase
                 array(
                     'name' => 'mautic/grapes-js-builder-bundle', 
                     'type' => 'mautic-plugin', 
-                    'extra' => [
+                    'extra' => array(
                         'install-directory-name' => 'GrapesJsBuilderPlugin'
-                    ]
+                    )
                 ),
                 array(
                     'name' => 'GrapesJsBuilderPlugin', 
                     'type' => 'mautic-plugin', 
-                    'extra' => [
+                    'extra' => array(
                         'install-directory-name' => 'GrapesJsBuilderPlugin'
-                    ]
+                    )
                 )                
             ),
             array(
@@ -95,16 +99,16 @@ class MauticInstallerTest extends BaseTestCase
                 array(
                     'name' => 'mautic/theme-blank-grapejs', 
                     'type' => 'mautic-theme', 
-                    'extra' => [
+                    'extra' => array(
                         'install-directory-name' => 'blank-grapejs'
-                    ]
+                    )
                 ),
                 array(
                     'name' => 'blank-grapejs', 
                     'type' => 'mautic-theme', 
-                    'extra' => [
+                    'extra' => array(
                         'install-directory-name' => 'blank-grapejs'
-                    ]
+                    )
                 )                
             )
         );

--- a/tests/Composer/Installers/Test/MauticInstallerTest.php
+++ b/tests/Composer/Installers/Test/MauticInstallerTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace Composer\Installers\Test;
+
+use Composer\Installers\MauticInstaller;
+use Composer\Package\Package;
+use Composer\Composer;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class MauticInstallerTest extends BaseTestCase
+{
+    /**
+     * @var MauticInstaller
+     */
+    private $installer;
+
+    public function setUp()
+    {
+        $this->composer = new Composer();
+    }
+
+    /**
+     * @param string[] $vars
+     * @param string[] $expectedVars
+     *
+     * @covers ::inflectPackageVars
+     *
+     * @dataProvider provideExpectedInflectionResults
+     */
+    final public function testInflectPackageVars($vars, $expectedVars)
+    {
+        $package = new Package($vars['name'], '1.0.0', '1.0.0');
+        $package->setType($vars['type']);
+        if (isset($vars['extra'])) {
+            $package->setExtra($vars['extra']);
+        }
+
+        $installer = new MauticInstaller(
+            $package,
+            $this->composer
+        );
+
+        $actual = $installer->inflectPackageVars($vars);
+        $this->assertEquals($actual, $expectedVars);
+    }
+
+    /**
+     * Provides various parameters for packages and the expected result after
+     * inflection
+     *
+     * @return array
+     */
+    final public function provideExpectedInflectionResults()
+    {
+        return array(
+            //check bitrix-dir is correct
+            array(
+                array(
+                    'name' => 'mautic/grapes-js-builder-bundle', 
+                    'type' => 'mautic-plugin'
+                ),
+                array(
+                    'name' => 'GrapesJsBuilderBundle',
+                    'type' => 'mautic-plugin'
+                )
+            ),
+            // Check if composer renames the name based on the given
+            // installation directory
+            array(
+                array(
+                    'name' => 'mautic/grapes-js-builder-bundle', 
+                    'type' => 'mautic-plugin', 
+                    'extra' => [
+                        'install-directory-name' => 'GrapesJsBuilderPlugin'
+                    ]
+                ),
+                array(
+                    'name' => 'GrapesJsBuilderPlugin', 
+                    'type' => 'mautic-plugin', 
+                    'extra' => [
+                        'install-directory-name' => 'GrapesJsBuilderPlugin'
+                    ]
+                )                
+            ),
+            array(
+                array(
+                    'name' => 'mautic/theme-blank-grapejs', 
+                    'type' => 'mautic-theme'
+                ),
+                array(
+                    'name' => 'ThemeBlankGrapejs', 
+                    'type' => 'mautic-theme'
+                )
+            ),
+            array(
+                array(
+                    'name' => 'mautic/theme-blank-grapejs', 
+                    'type' => 'mautic-theme', 
+                    'extra' => [
+                        'install-directory-name' => 'blank-grapejs'
+                    ]
+                ),
+                array(
+                    'name' => 'blank-grapejs', 
+                    'type' => 'mautic-theme', 
+                    'extra' => [
+                        'install-directory-name' => 'blank-grapejs'
+                    ]
+                )                
+            )
+        );
+    }
+}


### PR DESCRIPTION
Update MauticInstaller to allow plugins & themes with custom directory names - this has been verified (composer create-project mautic/recommended-project:4.x-dev mauticcomposerproject --no-interaction) and can be committed!

I know the suggestion is to use installer-name, but there was a composer library https://github.com/mautic/composer-plugin that already had the convention of install-directory-name so I wanted to keep compatibility with that.