### PR TITLE
Use fully qualified theme names

### DIFF
--- a/src/Composer/Installers/OctoberInstaller.php
+++ b/src/Composer/Installers/OctoberInstaller.php
@@ -6,7 +6,7 @@ class OctoberInstaller extends BaseInstaller
     protected $locations = array(
         'module'    => 'modules/{$name}/',
         'plugin'    => 'plugins/{$vendor}/{$name}/',
-        'theme'     => 'themes/{$name}/'
+        'theme'     => 'themes/{$vendor}-{$name}/'
     );
 
     /**
@@ -41,6 +41,7 @@ class OctoberInstaller extends BaseInstaller
     protected function inflectThemeVars($vars)
     {
         $vars['name'] = preg_replace('/^oc-|-theme$/', '', $vars['name']);
+        $vars['vendor'] = preg_replace('/[^a-z0-9_]/i', '', $vars['vendor']);
 
         return $vars;
     }

--- a/tests/Composer/Installers/Test/InstallerTest.php
+++ b/tests/Composer/Installers/Test/InstallerTest.php
@@ -395,7 +395,7 @@ class InstallerTest extends TestCase
             array('moodle-mod', 'mod/my_package/', 'shama/my_package'),
             array('october-module', 'modules/my_plugin/', 'shama/my_plugin'),
             array('october-plugin', 'plugins/shama/my_plugin/', 'shama/my_plugin'),
-            array('october-theme', 'themes/my_theme/', 'shama/my_theme'),
+            array('october-theme', 'themes/shama-my_theme/', 'shama/my_theme'),
             array('piwik-plugin', 'plugins/VisitSummary/', 'shama/visit-summary'),
             array('prestashop-module', 'modules/a-module/', 'vendor/a-module'),
             array('prestashop-theme', 'themes/a-theme/', 'vendor/a-theme'),


### PR DESCRIPTION
October CMS co-founder here 👋 A small bug that took a while to manifest, the theme names can conflict and create all sorts of chaos.

While both are technically fine, this is not a breaking change, it just prevents conflicts with authors where the theme name is identical, in forward-looking installations