### PR TITLE
Update TastyIgniterInstaller.php

### DIFF
--- a/src/Composer/Installers/TastyIgniterInstaller.php
+++ b/src/Composer/Installers/TastyIgniterInstaller.php
@@ -19,7 +19,7 @@ class TastyIgniterInstaller extends BaseInstaller
      */
     public function inflectPackageVars(array $vars): array
     {
-        $extra = $this->composer->getPackage()->getExtra();
+        $extra = $this->package->getExtra();
 
         if ($vars['type'] === 'tastyigniter-extension') {
             if (!empty($extra['tastyigniter-extension']['code'])) {


### PR DESCRIPTION
Pulls composer.json `extra` data from the package being installed instead of the root one.