### PR TITLE
Remove homepage from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
         "Zend",
         "Zikula"
     ],
-    "homepage": "https://composer.github.io/installers/",
     "authors": [
         {
             "name": "Kyle Robinson Young",


### PR DESCRIPTION
The [GitHub page](https://composer.github.io/installers/) is disabled. The readme file of the project is enough.