### PR TITLE
Remove 'module' installation path from TheliaInstaller

### DIFF
--- a/src/Composer/Installers/TheliaInstaller.php
+++ b/src/Composer/Installers/TheliaInstaller.php
@@ -6,7 +6,6 @@ class TheliaInstaller extends BaseInstaller
 {
     /** @var array<string, string> */
     protected $locations = array(
-        'module'                => 'local/modules/{$name}/',
         'frontoffice-template'  => 'templates/frontOffice/{$name}/',
         'backoffice-template'   => 'templates/backOffice/{$name}/',
         'email-template'        => 'templates/email/{$name}/',


### PR DESCRIPTION
The 'module' path configuration has been removed from the TheliaInstaller. This change streamlines the installer by focusing only on template-related paths.